### PR TITLE
Fixed the default synchronization interval in the help text (bsc#978453)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ stamp-h*
 Makefile.am.common
 *.ami
 *.bz2
-*.spec
 .dep
 tmp.*
 *.log

--- a/package/yast2-ntp-client.changes
+++ b/package/yast2-ntp-client.changes
@@ -6,7 +6,7 @@ Fri May  6 16:09:50 UTC 2016 - lslezak@suse.cz
 - Unify the default value in the code (the proposal client used
   a different default)
 - Set the initial state of the interval widget according to
-  the current synchronization mode
+  the current synchronization mode (bsc#978892)
 - Fixed firewall widget layout (double frame widget)
 - 3.1.23
 

--- a/package/yast2-ntp-client.changes
+++ b/package/yast2-ntp-client.changes
@@ -1,4 +1,16 @@
 -------------------------------------------------------------------
+Fri May  6 16:09:50 UTC 2016 - lslezak@suse.cz
+
+- Fixed the default synchronization interval in the help text
+  (bsc#978453)
+- Unify the default value in the code (the proposal client used
+  a different default)
+- Set the initial state of the interval widget according to
+  the current synchronization mode
+- Fixed firewall widget layout (double frame widget)
+- 3.1.23
+
+-------------------------------------------------------------------
 Thu Apr 14 09:16:37 CEST 2016 - kanderssen@suse.com
 
 - Calls to sntp adjusted to the syntax of ntp 4.2.8

--- a/package/yast2-ntp-client.spec
+++ b/package/yast2-ntp-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ntp-client
-Version:        3.1.22
+Version:        3.1.23
 Release:        0
 Summary:        YaST2 - NTP Client Configuration
 License:        GPL-2.0+

--- a/src/clients/ntp-client_proposal.rb
+++ b/src/clients/ntp-client_proposal.rb
@@ -57,9 +57,7 @@ module Yast
 
 
 
-      if false
-        return
-      elsif @func == "GetNTPEnabled"
+      if @func == "GetNTPEnabled"
         @ret = GetNTPEnabled()
       elsif @func == "SetUseNTP"
         NtpClient.ntp_selected = Ops.get_boolean(@param, "ntp_used", false)
@@ -326,7 +324,7 @@ module Yast
       NtpClient.run_service = run_service
       if !run_service
         NtpClient.synchronize_time = true
-        NtpClient.sync_interval = 15
+        NtpClient.sync_interval = NtpClientClass::DEFAULT_SYNC_INTERVAL
       end
 
       #OK, so we stored the server address

--- a/src/include/ntp-client/dialogs.rb
+++ b/src/include/ntp-client/dialogs.rb
@@ -172,11 +172,7 @@ module Yast
               VSpacing(),
               Left("secure"),
               VSpacing(),
-              Frame(
-                # TRANSLATORS: UI frame label
-                _("Firewall Settings"),
-                "firewall"
-              )
+              "firewall"
             )
           ),
           VStretch()

--- a/src/include/ntp-client/helps.rb
+++ b/src/include/ntp-client/helps.rb
@@ -8,6 +8,7 @@
 # $Id$
 module Yast
   module NtpClientHelpsInclude
+    Yast.import "NtpClient"
     def initialize_ntp_client_helps(include_target)
       textdomain "ntp-client"
 
@@ -31,16 +32,14 @@ module Yast
               "Abort the save procedure by pressing  <b>Abort</b>.\n" +
               "An additional dialog will inform you whether it is safe to do so.</p>"
           ),
-        # help text 1/5
+        # help text 1/5, %d is a number of minutes
         "start"              => _(
           "<p><b><big>Start NTP Daemon</big></b><br>\n" +
             "Select whether to start the NTP daemon now and on every system boot. \n" +
-            "The NTP daemon resolves host names when initializing. Your\n" +
-            "network connection must be started before the NTP daemon starts.</p>\n" +
-	    "Selecting <b>Synchronize without Daemon</b> the ntp daemon will not be activated. \n" +
-	    "The system time will be set periodically. The interval is configurable. It is 15 minutes by default.\n " +
-	    "You can change this when the system was set up."
-	),
+	    "Selecting <b>Synchronize without Daemon</b> the ntp daemon will not be activated\n" +
+	    "and the system time will be set periodically by a <i>cron</i> script. \n" +
+      "The interval is configurable, by default it is %d minutes."
+	    ) % NtpClientClass::DEFAULT_SYNC_INTERVAL,
         # help text 2/5
         "chroot_environment" => _(
           "<p><b><big>Chroot Jail</big></b><br>\n" +

--- a/src/include/ntp-client/helps.rb
+++ b/src/include/ntp-client/helps.rb
@@ -36,7 +36,7 @@ module Yast
         "start"              => _(
           "<p><b><big>Start NTP Daemon</big></b><br>\n" +
             "Select whether to start the NTP daemon now and on every system boot. \n" +
-	    "Selecting <b>Synchronize without Daemon</b> the ntp daemon will not be activated\n" +
+	    "Selecting <b>Synchronize without Daemon</b> the NTP daemon will not be activated\n" +
 	    "and the system time will be set periodically by a <i>cron</i> script. \n" +
       "The interval is configurable, by default it is %d minutes."
 	    ) % NtpClientClass::DEFAULT_SYNC_INTERVAL,

--- a/src/include/ntp-client/widgets.rb
+++ b/src/include/ntp-client/widgets.rb
@@ -111,6 +111,9 @@ module Yast
     def intervalInit(id)
       UI.ChangeWidget(Id("interval"), :Value, NtpClient.sync_interval)
 
+      enabled = UI.QueryWidget(Id("start"), :CurrentButton) == "sync"
+      UI.ChangeWidget(Id("interval"), :Enabled, enabled)
+
       nil
     end
 

--- a/src/modules/NtpClient.rb
+++ b/src/modules/NtpClient.rb
@@ -14,6 +14,12 @@ require "yaml"
 
 module Yast
   class NtpClientClass < Module
+
+    # the default synchronization interval in minutes when running in the manual
+    # sync mode ("Synchronize without Daemon" option, ntp started from cron)
+    # Note: the UI field currently uses maximum of 60 minutes
+    DEFAULT_SYNC_INTERVAL = 5
+
     def main
       Yast.import "UI"
       textdomain "ntp-client"
@@ -61,7 +67,7 @@ module Yast
       @synchronize_time = false
 
       # The interval of synchronization in minutes.
-      @sync_interval = 5
+      @sync_interval = DEFAULT_SYNC_INTERVAL
 
       # The cron file name for the synchronization.
       @cron_file = "/etc/cron.d/novell.ntp-synchronize"
@@ -462,7 +468,7 @@ module Yast
       Builtins.y2milestone("CRONTAB %1", crontab)
       tmp = Ops.get_string(crontab, [0, "events", 0, "active"], "0")
       @synchronize_time = tmp == "1"
-      tmp = Ops.get_string(crontab, [0, "events", 0, "minute"], "*/5")
+      tmp = Ops.get_string(crontab, [0, "events", 0, "minute"], "*/#{DEFAULT_SYNC_INTERVAL}")
       Builtins.y2milestone("MINUTE %1", tmp)
       pos = Builtins.regexppos(tmp, "[0-9]+")
       tmp2 = Builtins.substring(
@@ -930,7 +936,7 @@ module Yast
     def Import(settings)
       settings = deep_copy(settings)
       @synchronize_time = Ops.get_boolean(settings, "synchronize_time", false)
-      @sync_interval = Ops.get_integer(settings, "sync_interval", 5)
+      @sync_interval = Ops.get_integer(settings, "sync_interval", DEFAULT_SYNC_INTERVAL)
       @run_service = Ops.get_boolean(settings, "start_at_boot", false)
       @run_chroot = Ops.get_boolean(settings, "start_in_chroot", true)
       # compatibility: configure_dhcp:true translates to ntp_policy:auto


### PR DESCRIPTION
Originally I wanted to simply fix a trivial [bug 978453](https://bugzilla.suse.com/show_bug.cgi?id=978453) - the default value in the help text did not match the value in the UI, but after looking into it I found several hidden skeletons or zombies...

# Changes

- Unify the default value in the code (BTW the proposal client used   a different default)
- Set the initial state of the interval widget according to the current synchronization mode
- Fixed firewall widget layout (double frame widget)
- 3.1.23

# Screenshots

Here are the screenshots showing the fixes in the UI.

## Initializing the "Interval" widget

### Original State

After starting the module the *Inverval of the Synchronization in Minutes* widget was enabled although the initial start mode was *Now and on Boot*. The setting makes sense only in the *Synchronize without Daemon* mode.

If you change the mode to something else and then set it back then the widget is properly disabled. So changing the mode is handled properly, only the initial state was not set correctly:

![ntp_orig_init](https://cloud.githubusercontent.com/assets/907998/15106046/d46bf646-15c6-11e6-8106-64cad36ed9d7.png)

### Fixed

After fix the initial state is correctly set to disabled when the start mode is *Now and on Boot*:

![ntp_fix_init](https://cloud.githubusercontent.com/assets/907998/15106048/d46eeaea-15c6-11e6-8355-36959317e227.png)

## Double Frame for the Firewall widget

### Original State

Originally there were displayed two `Frame` widgets around the Firewall settings:

![ntp_orig_sec](https://cloud.githubusercontent.com/assets/907998/15106047/d46ce920-15c6-11e6-81da-365a95fad740.png)

### Fixed

The fix removed one of them:

![ntp_fix_sec](https://cloud.githubusercontent.com/assets/907998/15106049/d471855c-15c6-11e6-9377-bdc0a3501a55.png)

