### PR TITLE
Calls to sntp adjusted to syntax from ntp 4.2.8 (bsc#979421)

### DIFF
--- a/package/yast2-ntp-client.changes
+++ b/package/yast2-ntp-client.changes
@@ -2,7 +2,7 @@
 Mon May 23 06:19:31 UTC 2016 - kanderssen@suse.com
 
 - Calls to sntp adjusted to the syntax of ntp 4.2.8
-  (bsc#bsc#979421)
+  (bsc#979421)
 - 3.1.12.1
 
 -------------------------------------------------------------------

--- a/package/yast2-ntp-client.changes
+++ b/package/yast2-ntp-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 23 06:19:31 UTC 2016 - kanderssen@suse.com
+
+- Calls to sntp adjusted to the syntax of ntp 4.2.8
+  (bsc#bsc#979421)
+- 3.1.12.1
+
+-------------------------------------------------------------------
 Tue Sep  2 10:00:18 UTC 2014 - cwh@suse.com
 
 - Using Report.Error to be autoyast-proof

--- a/package/yast2-ntp-client.spec
+++ b/package/yast2-ntp-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ntp-client
-Version:        3.1.12
+Version:        3.1.12.1
 Release:        0
 Summary:        YaST2 - NTP Client Configuration
 License:        GPL-2.0+
@@ -36,6 +36,7 @@ BuildRequires:  yast2-testsuite
 Requires:       yast2 >= 3.1.11
 Requires:       yast2-country-data
 Requires:       yast2-ruby-bindings >= 1.0.0
+Conflicts:      ntp < 4.2.8p7
 BuildArch:      noarch
 
 

--- a/src/clients/ntp-client_proposal.rb
+++ b/src/clients/ntp-client_proposal.rb
@@ -399,13 +399,18 @@ module Yast
 
         Builtins.y2milestone("Running sntp to sync with %1", ntp_server)
 
-        # -s: do set the system time
+
+        # -S: do set the system time
         # -t 5: timeout of 5 seconds
+        # -K /dev/null: use /dev/null as KoD history file (if not specified,
+        #               /var/db/ntp-kod will be used and it doesn't exist)
         # -l <file>: log to a file to not mess text mode installation
+        # -c: causes all IP addresses to which ntp_server resolves to be queried in parallel
         ret = SCR.Execute(
                 path(".target.bash"),
-                "/usr/sbin/sntp -l /var/log/YaST2/sntp.log -t 5 -s '#{String.Quote(ntp_server)}'"
+                "/usr/sbin/sntp -S -K /dev/null -l /var/log/YaST2/sntp.log -t 5 -c '#{String.Quote(ntp_server)}'"
               )
+
         Builtins.y2milestone("'sntp %1' returned %2", ntp_server, ret)
         Popup.ClearFeedback
       end

--- a/src/modules/NtpClient.rb
+++ b/src/modules/NtpClient.rb
@@ -1070,9 +1070,13 @@ module Yast
       )
 
       Builtins.y2milestone("sntp test response: #{output}")
+
       # sntp returns always 0 if not called with option -S or -s (set system time)
       # so this is a workaround at least to return false in case server is not
-      # reachable.
+      # reachable. We could also take care of stdout checking if it includes
+      # "no (U|B)CST reponse", but it also implies be to dependent in the
+      # future and the ntp package should take care of it and aswer other exit
+      # code instead of 0
       output["stderr"].include?("lookup error") ? false : output["exit"] == 0
     end
 

--- a/src/modules/NtpClient.rb
+++ b/src/modules/NtpClient.rb
@@ -1045,42 +1045,58 @@ module Yast
       summary
     end
 
+
     # Test if specified NTP server answers
+    # @param [String] server string host name or IP address of the NTP server
+    # @return [Boolean] true if NTP server answers properly
+    def reachable_ntp_server?(server)
+      # testing the server using IPv4 and then using IPv6 protocol
+      # bug #74076, Firewall could have been blocked IPv6
+      return true if sntp_test(server) == 0
+
+      sntp_test(server, 6) == 0
+    end
+
+    # -K /dev/null: use /dev/null as KoD history file (if not specified,
+    #               /var/db/ntp-kod will be used and it doesn't exist)
+    # -c: concurrently query all IPs; -t 5: five seconds of timeout
+    # @param [String] server string host name or IP address of the NTP server
+    # @param [Fixnum] integer ip version to use (4 or 6)
+    # @return [Fixnum] sntp exit code or 1 in case of lookup error
+    def sntp_test(server, ip_version = 4)
+      output = SCR.Execute(
+        path(".target.bash_output"),
+        "/usr/sbin/sntp -#{ip_version} -K /dev/null -t 5 -c #{server}"
+      )
+
+      Builtins.y2milestone("sntp test response: #{output}")
+      # sntp returns always 0 if not called with option -S or -s (set system time)
+      # so this is a workaround at least to return 1 in case server is not
+      # reachable
+      return 1 if output["stderr"].include?("lookup error")
+
+      output["exit"]
+    end
+
+    # Handle UI of NTP server test answers
     # @param [String] server string host name or IP address of the NTP server
     # @param [Symbol] verbosity `no_ui: ..., `transient_popup: pop up while scanning,
     #                  `result_popup: also final pop up about the result
     # @return [Boolean] true if NTP server answers properly
     def TestNtpServer(server, verbosity)
-      if verbosity != :no_ui
-        UI.OpenDialog(
-          # An informative popup label diring the NTP server testings
-          Left(Label(_("Testing the NTP server...")))
-        )
-      end
+      return reachable_ntp_server?(server) if verbosity == :no_ui
+
+      UI.OpenDialog(
+        # An informative popup label diring the NTP server testings
+        Left(Label(_("Testing the NTP server...")))
+      )
 
       Builtins.y2milestone("Testing reachability of server %1", server)
 
-      # testing the server using IPv4 and then using IPv6 protocol
-      # bug #74076, Firewall could have been blocked IPv6
-      ret_IPv4 = Convert.to_integer(
-        SCR.Execute(
-          path(".target.bash"),
-          Builtins.sformat("/usr/sbin/sntp -4 -t 5 %1", server)
-        )
-      )
-      ret_IPv6 = 0
-      if ret_IPv4 != 0
-        ret_IPv6 = Convert.to_integer(
-          SCR.Execute(
-            path(".target.bash"),
-            Builtins.sformat("/usr/sbin/sntp -6 -t 5 %1", server)
-          )
-        )
-      end
+      ok = reachable_ntp_server?(server)
 
-      UI.CloseDialog if verbosity != :no_ui
+      UI.CloseDialog
 
-      ok = ret_IPv4 == 0 || ret_IPv6 == 0
       if verbosity == :result_popup
         if ok
           # message report - result of test of connection to NTP server

--- a/src/modules/NtpClient.rb
+++ b/src/modules/NtpClient.rb
@@ -1051,15 +1051,14 @@ module Yast
     # @param [String] server string host name or IP address of the NTP server
     # @return [Boolean] true if NTP server answers properly
     def reachable_ntp_server?(server)
-      return true if sntp_test(server)
-
-      sntp_test(server, 6)
+      sntp_test(server) || sntp_test(server, 6)
     end
 
     # Test NTP server answer for a given IP version.
     # @param [String] server string host name or IP address of the NTP server
     # @param [Fixnum] integer ip version to use (4 or 6)
-    # @return [Fixnum] sntp exit code or 1 in case of lookup error
+    # @return [Boolean] true if stderr does not include lookup error and exit
+    # code is 0
     def sntp_test(server, ip_version = 4)
       output = SCR.Execute(
         path(".target.bash_output"),
@@ -1074,7 +1073,7 @@ module Yast
       # sntp returns always 0 if not called with option -S or -s (set system time)
       # so this is a workaround at least to return false in case server is not
       # reachable. We could also take care of stdout checking if it includes
-      # "no (U|B)CST reponse", but it also implies be to dependent in the
+      # "no (U|B)CST reponse", but it also implies be too dependent in the
       # future and the ntp package should take care of it and aswer other exit
       # code instead of 0
       output["stderr"].include?("lookup error") ? false : output["exit"] == 0


### PR DESCRIPTION
I have updated the syntax of sntp call, but also we check now if the server is not reachable checking the presence of "lookup error" in the stderr **[[1]]**.

![screenshot_opensuse13_2016-05-23_07 36 48](https://cloud.githubusercontent.com/assets/7056681/15462975/360849ac-20be-11e6-99f0-8ffdabc09040.png)

![screenshot_opensuse13_2016-05-23_07 36 28](https://cloud.githubusercontent.com/assets/7056681/15462973/335f444e-20be-11e6-9192-6cb6b9dea134.png)


I added this check because sntp always returns 0 although the server is not answering or not reachable, so the current NTP Test is useless.

We could do more checks like for example check if stdout includes "no UCST reponse" **[[2]]** and maybe other checks, but i'm afraid the answer could change or be very dependent of current responses what could need updates each time the response changes but on the other hand this is only a Test functionality and for this reason not a critical one.

[1]: https://github.com/ntp-project/ntp/blob/1a399a03e674da08cfce2cdb847bfb65d65df237/sntp/main.c#L461
[2]: https://github.com/ntp-project/ntp/blob/1a399a03e674da08cfce2cdb847bfb65d65df237/sntp/main.c#L791


