### PR TITLE
Convert ntp record's comment to string to avoid nil values (bsc#977610)

### DIFF
--- a/package/yast2-ntp-client.changes
+++ b/package/yast2-ntp-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun 14 06:54:54 UTC 2016 - kanderssen@suse.com
+
+- Fix handling of NTP records without comments (bsc#977610)
+- 3.1.26
+
+-------------------------------------------------------------------
 Thu Jun  2 07:40:56 UTC 2016 - kanderssen@suse.com
 
 - Fixed Ntp Test adding a workaround to return false in case given

--- a/package/yast2-ntp-client.spec
+++ b/package/yast2-ntp-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ntp-client
-Version:        3.1.25
+Version:        3.1.26
 Release:        0
 Summary:        YaST2 - NTP Client Configuration
 License:        GPL-2.0+

--- a/src/modules/NtpClient.rb
+++ b/src/modules/NtpClient.rb
@@ -1158,11 +1158,11 @@ module Yast
 
     def record_to_h(record)
       {
-        "comment" => record["comment"],
+        "comment" => record["comment"].to_s,
         "kind"    => "value",
         "name"    => record["type"] == "__clock" ? "server" : record["type"],
         "type"    => 0,
-        "value"   => "#{record["address"]} #{record["options"]}"
+        "value"   => "#{record["address"]} #{record["options"]}".strip
       }
     end
 
@@ -1170,11 +1170,11 @@ module Yast
     # write
     def fugde_options_to_h(record)
       {
-        "comment" => record["fudge_comment"],
+        "comment" => record["fudge_comment"].to_s,
         "kind"    => "value",
         "name"    => "fudge",
         "type"    => 0,
-        "value"   => "#{record["address"]} #{record["fudge_options"]}"
+        "value"   => "#{record["address"]} #{record["fudge_options"]}".strip
       }
     end
 


### PR DESCRIPTION
If nil comments are given then an empty server entry will be written to /etc/ntp.conf