### PR TITLE
Fixed some tests (bsc#983486).

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,20 @@
+#! /bin/bash
+
+# exit on error immediately and print the executed commands
+set -e -x
+
+rake check:pot
+rubocop.ruby2.2
+yardoc.ruby2.2
+# enable coveralls reports
+COVERAGE=1 CI=1 TRAVIS=1 rake test:unit
+
+# build the binary package locally, use plain "rpmbuild" to make it simple
+rake tarball
+cp package/* /usr/src/packages/SOURCES/
+rpmbuild -bb package/*.spec
+
+# test the %pre/%post script by installing/updating/removing the package
+rpm -iv /usr/src/packages/RPMS/noarch/*.rpm
+rpm -Uv --force /usr/src/packages/RPMS/noarch/*.rpm
+rpm -ev yast2-ntp-client

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,9 @@
-language: cpp
-compiler:
-    - gcc
-before_install:
-    # disable rvm, use system Ruby
-    - rvm reset
-    # install newer augeasget repo with newer augeas, otherwise ruby-augeas fails (see https://github.com/yast/yast-network/pull/454#issuecomment-253795507)
-    - sudo add-apt-repository -y ppa:raphink/augeas
-    - sudo apt-get update
-    - sudo apt-get install libaugeas-dev libxml2-dev
-    # end of augeas install
-    - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
-    - sh ./travis_setup.sh -p "rake yast2-devtools yast2 rake yast2-country-data libaugeas-dev" -g "yast-rake gettext yard rspec:3.3.0 simplecov coveralls rubocop:0.29.1 cfa"
-script:
-    - rake check:syntax
-    - rake check:pot
-    - rubocop
-    - yardoc
-    - COVERAGE=1 rake test:unit
-    - sudo rake install
+sudo: required
+language: ruby
+services:
+  - docker
 
+before_install:
+  - docker build -t yast-devel-tw .
+script:
+  - docker run -it -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-devel-tw ./.travis.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM opensuse:tumbleweed
+RUN zypper ar -f http://download.opensuse.org/repositories/YaST:/Head/openSUSE_Tumbleweed/ yast
+RUN zypper --gpg-auto-import-keys --non-interactive in \
+      fdupes \
+      grep \
+      yast2-devtools \
+      perl-XML-Writer \
+      yast2 \
+      yast2-country-data \
+      yast2-devtools \
+      'rubygem(rspec)' \
+      'rubygem(yast-rake)' \
+      augeas-lenses \
+      'rubygem(cfa)' \
+      'rubygem(gettext)' \
+      'rubygem(simplecov)' \
+      update-desktop-files \
+      git \
+      rpm-build \
+      which
+# FIXME: fix the dependency issues in YaST:Head and install them via zypper
+# FIXME: switch to Rubocop 0.41.2 as the rest of YaST
+RUN gem install --no-document coveralls yard rubocop:0.29.1
+COPY . /tmp/sources
+WORKDIR /tmp/sources
+

--- a/package/yast2-ntp-client.changes
+++ b/package/yast2-ntp-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec 15 12:19:27 UTC 2016 - kanderssen@suse.com
+
+- Fixed some tests that were passing because of an old ntp augeas
+  lense (bsc#983486).
+- 3.2.3
+
+-------------------------------------------------------------------
 Fri Dec  2 14:37:28 UTC 2016 - joseivanlopez@gmail.com
 
 - Updated client to read/write NTP configuration using CFA

--- a/package/yast2-ntp-client.spec
+++ b/package/yast2-ntp-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ntp-client
-Version:        3.2.2
+Version:        3.2.3
 Release:        0
 Summary:        YaST2 - NTP Client Configuration
 License:        GPL-2.0+
@@ -65,7 +65,7 @@ rake install DESTDIR="%{buildroot}"
 %files
 %defattr(-,root,root)
 %dir %{yast_yncludedir}/ntp-client
-%{yast_dir}/clients/*
+%{yast_clientdir}/*
 %{yast_dir}/lib
 %{yast_yncludedir}/ntp-client/*
 %{yast_scrconfdir}/cfg_ntp.scr

--- a/package/yast2-ntp-client.spec
+++ b/package/yast2-ntp-client.spec
@@ -65,9 +65,9 @@ rake install DESTDIR="%{buildroot}"
 %files
 %defattr(-,root,root)
 %dir %{yast_yncludedir}/ntp-client
+%{yast_dir}/clients/*
+%{yast_dir}/lib
 %{yast_yncludedir}/ntp-client/*
-%{yast_clientdir}/ntp-client.rb
-%{yast_clientdir}/ntp-client_*.rb
 %{yast_scrconfdir}/cfg_ntp.scr
 %{yast_scrconfdir}/etc_ntp.scr
 %{yast_moduledir}/*.rb

--- a/test/cfa/ntp_conf_test.rb
+++ b/test/cfa/ntp_conf_test.rb
@@ -359,13 +359,13 @@ describe CFA::NtpConf::RestrictRecord do
 
   describe "#options" do
     it "obtains the options of the record" do
-      expect(record.options).to eq(%w(default notrap nomodify nopeer))
+      expect(record.options).to eq(%w(notrap nomodify nopeer))
     end
   end
 
   context "#options=" do
     it "sets options to the record" do
-      options = ["default", "notrap"]
+      options = ["notrap"]
       record.options = options
       expect(record.options).to eq(options)
       ntp.save
@@ -375,14 +375,14 @@ describe CFA::NtpConf::RestrictRecord do
 
   describe "#raw_options" do
     it "obtains options as string" do
-      expect(record.raw_options).to eq("default notrap nomodify nopeer")
+      expect(record.raw_options).to eq("notrap nomodify nopeer")
     end
   end
 
   describe "#raw_options=" do
     it "sets options from a string" do
-      record.raw_options = "default notrap"
-      expect(record.options).to eq(["default", "notrap"])
+      record.raw_options = "notrap"
+      expect(record.options).to eq(["notrap"])
       ntp.save
       expect(file.content).to include("restrict -4 default notrap\n")
     end

--- a/test/ntp_client_test.rb
+++ b/test/ntp_client_test.rb
@@ -294,6 +294,7 @@ describe Yast::NtpClient do
   describe "#DeActivateRandomPoolServersFunction" do
     it "removes random pool ntp servers from @ntp_records" do
       allow(CFA::NtpConf).to receive(:new).and_return(ntp_conf)
+      allow(Yast::FileUtils).to receive(:Exists).with("/etc/ntp.conf").and_return(true)
       subject.instance_variable_set(:@config_has_been_read, false)
       load_records
 
@@ -523,6 +524,7 @@ describe Yast::NtpClient do
     end
 
     it "returns a list of NTP servers used in the current configuration" do
+      allow(Yast::FileUtils).to receive(:Exists).with("/etc/ntp.conf").and_return(true)
       allow(CFA::NtpConf).to receive(:new).and_return(ntp_conf)
       subject.instance_variable_set(:@config_has_been_read, false)
       load_records
@@ -621,6 +623,7 @@ describe Yast::NtpClient do
     end
 
     before do
+      allow(Yast::FileUtils).to receive(:Exists).with("/etc/ntp.conf").and_return(true)
       allow(CFA::NtpConf).to receive(:new).and_return(ntp_conf)
       subject.instance_variable_set(:@config_has_been_read, false)
       load_records
@@ -655,6 +658,7 @@ describe Yast::NtpClient do
     before do
       allow(CFA::NtpConf).to receive(:new).and_return(ntp_conf)
       subject.instance_variable_set(:@config_has_been_read, false)
+      allow(Yast::FileUtils).to receive(:Exists).with("/etc/ntp.conf").and_return(true)
     end
 
     it "returns false if config has been read previously" do
@@ -679,7 +683,7 @@ describe Yast::NtpClient do
     end
 
     it "initializes restrict records" do
-      expect(subject.restrict_map.size).to eql(4)
+      expect(subject.restrict_map.size).to eql(3)
       subject.ProcessNtpConf
     end
   end


### PR DESCRIPTION
Just fixed some tests that does not allow to build the package correctly. Travis does not complain because it uses the old ntp.lense

Josef Reidinger fixed the ntp lense in this commit:

hercules-team/augeas@01e4c42

Basically before the fix it doesn't expect to have restrict records with IPv4 explicitly, as for example:

`restrict -4 default`

So before the fix `-4` was treated as an **address** and `default` as an **option* what is wrong.

With the new lense, **cfa** will read the **IP version** correctly.

**IN PROCCESS**
```
The ubuntu repository for augeas is ppa:raphink/augeas, which installs:
Setting up augeas-lenses (1.4.0-0ubuntu1~augeas1~precise4) ...
Setting up libaugeas0 (1.4.0-0ubuntu1~augeas1~precise4) ...
```
We need updated packages.
