### PR TITLE
Add CFA class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,13 @@ compiler:
 before_install:
     # disable rvm, use system Ruby
     - rvm reset
+    # install newer augeasget repo with newer augeas, otherwise ruby-augeas fails (see https://github.com/yast/yast-network/pull/454#issuecomment-253795507)
+    - sudo add-apt-repository -y ppa:raphink/augeas
+    - sudo apt-get update
+    - sudo apt-get install libaugeas-dev libxml2-dev
+    # end of augeas install
     - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
-    - sh ./travis_setup.sh -p "rake yast2-devtools yast2 rake yast2-country-data" -g "yast-rake gettext yard rspec:3.3.0 simplecov coveralls rubocop:0.29.1"
+    - sh ./travis_setup.sh -p "rake yast2-devtools yast2 rake yast2-country-data libaugeas-dev" -g "yast-rake gettext yard rspec:3.3.0 simplecov coveralls rubocop:0.29.1 cfa"
 script:
     - rake check:syntax
     - rake check:pot

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require "yast/rake"
 
-Yast::Tasks.submit_to :sle12sp2
+Yast::Tasks.submit_to :casp10
 
 Yast::Tasks.configuration do |conf|
   # lets ignore license check for now

--- a/package/yast2-ntp-client.changes
+++ b/package/yast2-ntp-client.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Apr 21 15:32:37 UTC 2017 - igonzalezsosa@suse.com
+
+- Add a CFA class to handle ntp.conf (backported from the 3.2.x
+  branch)
+- NtpClient module does not use this new class
+- 3.1.28.1
+
+-------------------------------------------------------------------
 Thu Aug 11 14:24:42 CEST 2016 - schubi@suse.de
 
 - Error while using <type>__clock</type> in AutoYaST.

--- a/package/yast2-ntp-client.spec
+++ b/package/yast2-ntp-client.spec
@@ -31,6 +31,7 @@ BuildRequires:  yast2-country-data
 BuildRequires:  yast2-devtools >= 3.1.10
 BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
+BuildRequires:  augeas-lenses
 
 #SLPAPI.pm 
 # Hostname::CurrentDomain
@@ -70,6 +71,7 @@ rake install DESTDIR="%{buildroot}"
 %{yast_desktopdir}/ntp-client.desktop
 %{yast_ydatadir}/ntp_servers.yml
 %{yast_schemadir}/autoyast/rnc/ntpclient.rnc
+%{yast_dir}/lib
 
 %dir %{yast_docdir}
 %doc %{yast_docdir}/COPYING

--- a/package/yast2-ntp-client.spec
+++ b/package/yast2-ntp-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ntp-client
-Version:        3.1.28
+Version:        3.1.28.1
 Release:        0
 Summary:        YaST2 - NTP Client Configuration
 License:        GPL-2.0+

--- a/src/lib/cfa/ntp_conf.rb
+++ b/src/lib/cfa/ntp_conf.rb
@@ -1,0 +1,476 @@
+require "cfa/base_model"
+require "cfa/augeas_parser"
+require "cfa/matcher"
+
+module CFA
+  # class representings /etc/ntp.conf file model. It provides helper to manipulate
+  # with file. It uses CFA framework and Augeas parser.
+  # @see http://www.rubydoc.info/github/config-files-api/config_files_api/CFA/BaseModel
+  # @see http://www.rubydoc.info/github/config-files-api/config_files_api/CFA/AugeasParser
+  #
+  # In NTP files some keys can be present multiple times.
+  #
+  # For example:
+  #
+  # server 1.pool.ntp.org iburst
+  # server 2.pool.ntp.org
+  # server 127.127.1.0
+  # fudge 127.127.1.0 stratum 10
+  # peer 128.100.0.45
+  # peer 192.168.1.30
+  #
+  # Order of lines is not important, except for the
+  # fudge option that should immediately follow
+  # appropriate "server" option.
+  #
+  # Important keys (that are to be read and written) are
+  # server, peer, fudge, broadcast and broadcastclient.
+  class NtpConf < ::CFA::BaseModel
+    PARSER = CFA::AugeasParser.new("ntp.lns")
+
+    PATH = "/etc/ntp.conf".freeze
+
+    RECORD_ENTRIES = %w(
+      server
+      peer
+      broadcast
+      broadcastclient
+      manycast
+      manycastclient
+      fudge
+      restrict
+    ).freeze
+
+    COLLECTION_KEYS = (RECORD_ENTRIES + ["action"]).freeze
+
+    def initialize(file_handler: nil)
+      super(PARSER, PATH, file_handler: file_handler)
+    end
+
+    # Loads and fixes AugeasElement keys.
+    #
+    # AugeasParser returns collection entries with
+    # key ending in '[]', for example 'server[]'.
+    #
+    # If only exists one entry of the collection, parser
+    # return key without '[]'.
+    #
+    # For example:
+    #
+    # server 1.pool.ntp.org iburst
+    # server 2.pool.ntp.org
+    # peer 128.100.0.45
+    #
+    # In this case, key for peer entry is 'peer'.
+    # It is necessary to add '[]' to avoid possible
+    # write issues when more entries of that type
+    # are added.
+    def load
+      super
+      fix_keys(data)
+    end
+
+    # Obtains a collection that represents the
+    # entries of the file.
+    # @return [CollectionRecord] collection to
+    #   manipulate ntp entries.
+    #
+    # The collection preserves the order of the
+    # ntp entries in the file and only contains the
+    # entries of interest (see RECORD_ENTRIES).
+    def records
+      RecordCollection.new(data)
+    end
+
+    # Obtains raw content of the file.
+    # @return [String]
+    def raw
+      PARSER.serialize(data)
+    end
+
+  private
+
+    def fix_keys(tree)
+      tree.data.each do |entry|
+        entry[:key] << "[]" if COLLECTION_KEYS.include?(entry[:key])
+        fix_keys(entry[:value].tree) if entry[:value].is_a?(AugeasTreeValue)
+      end
+    end
+
+    # class to manage ntp entries as a collection.
+    #
+    # The collection preserves the order of the
+    # ntp entries in the file and only contains the
+    # entries of interest (see RECORD_ENTRIES).
+    #
+    # For example:
+    #
+    # server 1.pool.ntp.org iburst
+    # server 2.pool.ntp.org
+    # peer 128.100.0.45
+    #
+    # The collection contents a derived Record class
+    # object for each line. In this case, two
+    # ServerRecord and a PeerRecord.
+    class RecordCollection
+      include Enumerable
+
+      def initialize(augeas_tree)
+        @augeas_tree = augeas_tree
+      end
+
+      # Iterates the elements of the collection (@see Array#each).
+      # @yield [Record] gives a record of the collection
+      def each(&block)
+        record_entries.each(&block)
+      end
+
+      # Get last record in collection
+      def last
+        record_entries.last
+      end
+
+      # Adds a new Record object to the collection.
+      # @note argument is not member of collection and instead new instance
+      # is created from its augeas content.
+      # So for later modification please get new instance with `#last`.
+      # @param [Record] record
+      def <<(record)
+        @augeas_tree.add(record.augeas[:key], record.augeas[:value])
+        reset_cache
+      end
+
+      # Removes a Record object from the collection.
+      # @param [Record] record
+      def delete(record)
+        matcher = Matcher.new(
+          key:           record.augeas[:key],
+          value_matcher: record.augeas[:value]
+        )
+        @augeas_tree.delete(matcher)
+        reset_cache
+      end
+
+      # Removes all records that satisfy a condition.
+      # @yield [Record] gives a record of the collection
+      def delete_if(&block)
+        records = select(&block)
+        records.each { |record| delete(record) }
+      end
+
+      def empty?
+        count == 0
+      end
+
+      def ==(other)
+        other.to_a == to_a
+      end
+
+    private
+
+      def reset_cache
+        @record_entries = nil
+      end
+
+      def record_entries
+        return @record_entries if @record_entries
+        matcher = Matcher.new do |k, _v|
+          RECORD_ENTRIES.include?(k.gsub("[]", ""))
+        end
+        @record_entries = @augeas_tree.select(matcher).map do |e|
+          Record.new_from_augeas(e)
+        end
+      end
+    end
+
+    # Base class to represent a general ntp entry.
+    #
+    # This class is an AugeasElement wrapper. A Record
+    # has a value, and could also contains a comment and
+    # options. All its modifications are directly saved
+    # into augeas tree.
+    #
+    # Each ntp entry type has different interpretation
+    # for its options in the AugeasElement. For each one,
+    # a Record subclass is created.
+    class Record
+      # Creates the corresponding subclass object according
+      # to its AugeasElement key.
+      # @param [String] key
+      def self.new_from_augeas(augeas_entry)
+        record_class(augeas_entry[:key]).new(augeas_entry)
+      end
+
+      # Returns the corresponding subclass
+      # @param [string] key
+      def self.record_class(key)
+        entry_type = key.gsub("[]", "")
+        record_class = "::CFA::NtpConf::#{entry_type.capitalize}Record"
+        Kernel.const_get(record_class)
+      end
+
+      def initialize(augeas = nil)
+        augeas ||= create_augeas
+        @augeas = augeas
+      end
+
+      attr_reader :augeas
+
+      def value
+        tree_value? ? tree_value.value : @augeas[:value]
+      end
+
+      def value=(value)
+        if tree_value?
+          tree_value.value = value
+        else
+          @augeas[:value] = value
+          @augeas[:operation] ||= :add
+          @augeas[:operation] = :modify if @augeas[:operation] != :add
+        end
+      end
+
+      def comment
+        return nil unless tree_value?
+        tree_value.tree["#comment"]
+      end
+
+      # Comment is saved literally, so be sure that
+      # it is prepended by '#'
+      def comment=(comment)
+        ensure_tree_value
+        if comment.to_s == ""
+          tree_value.tree.delete("#comment")
+        else
+          tree_value.tree["#comment"] = comment
+        end
+      end
+
+      def options
+        raise NotImplementedError,
+          "Subclasses of #{Module.nesting.first} must override #{__method__}"
+      end
+
+      def options=(_options)
+        raise NotImplementedError,
+          "Subclasses of #{Module.nesting.first} must override #{__method__}"
+      end
+
+      def ==(other)
+        other.class == self.class && value == other.value
+      end
+
+      alias_method :eql?, :==
+
+      def type
+        @augeas[:key].gsub("[]", "")
+      end
+
+      # Returns an String representing the options
+      def raw_options
+        options.join(" ")
+      end
+
+      # Sets options from a String
+      def raw_options=(raw_options)
+        self.options = split_raw_options(raw_options)
+      end
+
+    protected
+
+      def create_augeas
+        { key: self.class.const_get("AUGEAS_KEY"), value: nil }
+      end
+
+      def tree_value?
+        @augeas[:value].is_a?(AugeasTreeValue)
+      end
+
+      def tree_value
+        @augeas[:value]
+      end
+
+      def ensure_tree_value
+        @augeas[:value] = AugeasTreeValue.new(
+          AugeasTree.new,
+          @augeas[:value]
+        ) unless tree_value?
+      end
+
+      def split_raw_options(raw_options)
+        raw_options.to_s.strip.gsub(/\s+/, " ").split(" ")
+      end
+
+      def augeas_options
+        tree_value.tree.select(options_matcher)
+      end
+
+      def options_matcher
+        Matcher.new { |k, _v| !k.include?("#comment") }
+      end
+    end
+
+    # class to represent a ntp command record entry. There is a
+    # subclass for server, peer, broadcast and broacastclient.
+    class CommandRecord < Record
+      def options
+        return [] unless tree_value?
+        augeas_options.map { |option| option[:key] }
+      end
+
+      def options=(options)
+        ensure_tree_value
+        tree_value.tree.delete(options_matcher)
+        options.each { |option| tree_value.tree.add(option, nil) }
+      end
+    end
+
+    # class to represent a ntp server entry.
+    # For example:
+    #   server 0.opensuse.pool.ntp.org iburst
+    class ServerRecord < CommandRecord
+      AUGEAS_KEY = "server[]".freeze
+    end
+
+    # class to represent a ntp peer entry.
+    # For example:
+    #   peer 128.100.0.45
+    class PeerRecord < CommandRecord
+      AUGEAS_KEY = "peer[]".freeze
+    end
+
+    # class to represent a ntp broadcast entry.
+    # For example:
+    #   broadcast 128.100.0.45
+    class BroadcastRecord < CommandRecord
+      AUGEAS_KEY = "broadcast[]".freeze
+    end
+
+    # class to represent a ntp broadcastclient entry.
+    class BroadcastclientRecord < CommandRecord
+      AUGEAS_KEY = "broadcastclient[]".freeze
+    end
+
+    # class to represent a ntp fudge entry.
+    #
+    # For example:
+    #   fudge  127.127.1.0 stratum 10
+    #
+    # Fudge entry has its own options interpretation.
+    class FudgeRecord < CommandRecord
+      AUGEAS_KEY = "fudge[]".freeze
+
+      def options
+        return {} unless tree_value?
+        augeas_options.each_with_object({}) do |option, opts|
+          opts[option[:key]] = option[:value]
+        end
+      end
+
+      def options=(options)
+        ensure_tree_value
+        tree_value.tree.delete(options_matcher)
+        options.each { |k, v| tree_value.tree.add(k, v) }
+      end
+
+      def raw_options
+        options.to_a.flatten.join(" ")
+      end
+
+      def raw_options=(raw_options)
+        options = split_raw_options(raw_options)
+        self.options = options.each_slice(2).to_a.to_h
+      end
+    end
+
+    # class to represent a ntp restrict entry.
+    #
+    # For example:
+    #   restrict -4 default notrap nomodify nopeer noquery
+    #
+    # Restrict entry has its own options interpretation.
+    class RestrictRecord < Record
+      AUGEAS_KEY = "restrict[]".freeze
+
+      def options
+        return [] unless tree_value?
+        res = augeas_options.map { |option| option[:value] }
+        res.shift if old_lens?
+
+        res
+      end
+
+      def options=(options)
+        # backward compatibility with old lens that set value ip restriction
+        # instead of address
+        if old_lens?
+          options = options.dup
+          address = augeas_options.map { |option| option[:value] }.first
+          options.unshift(address) if address
+        end
+
+        ensure_tree_value
+        tree_value.tree.delete(options_matcher)
+        options.each { |option| tree_value.tree.add("action[]", option) }
+      end
+
+      alias_method :orig_value, :value
+      def value
+        old_lens? ? augeas_options.map { |option| option[:value] }.first : orig_value
+      end
+
+      def value=(value)
+        if old_lens?
+          holder = tree_value.tree.select(options_matcher).first
+          holder[:value] = value
+          holder[:operation] = :modify
+        else
+          super
+        end
+      end
+
+    private
+
+      def options_matcher
+        Matcher.new { |k, _v| k.include?("action") }
+      end
+
+      # backward compatibility with old lens that set value ip restriction
+      # instead of address
+      # for old lens data can look like:
+      #   line in configuration file:
+      #     restrict -4 default nofail
+      #   augeas tree:
+      #     key:       restrict
+      #     value:     -4
+      #     action[1]: default
+      #     action[2]: nofail
+      #
+      #   line in configuration file:
+      #     restrict default nofail
+      #   augeas tree:
+      #     key:       restrict
+      #     value:     default
+      #     action[1]: nofail
+      #
+      # with new lens value is always address like:
+      #   line in configuration file:
+      #     restrict -4 default nofail
+      #   augeas tree:
+      #     key:       restrict
+      #     value:     default
+      #     action[1]: nofail
+      #     ipv4:      nil
+      #
+      #   line in configuration file:
+      #     restrict default nofail
+      #   augeas tree:
+      #     key: restrict
+      #     value: default
+      #     action[1]: nofail
+      def old_lens?
+        ["-6", "-4"].include?(orig_value)
+      end
+    end
+  end
+end

--- a/test/cfa/ntp_conf_test.rb
+++ b/test/cfa/ntp_conf_test.rb
@@ -1,0 +1,409 @@
+require_relative "../test_helper"
+require "cfa/memory_file"
+require "cfa/ntp_conf"
+
+def ntp_disk_content
+  path = File.expand_path("../../fixtures/cfa/ntp.conf", __FILE__)
+  File.read(path)
+end
+
+def ntp_file(content)
+  CFA::MemoryFile.new(content)
+end
+
+def ntp_conf(file)
+  CFA::NtpConf.new(file_handler: file)
+end
+
+describe CFA::NtpConf do
+  subject(:ntp) { ntp_conf(file) }
+
+  let(:file) { ntp_file(content) }
+
+  before do
+    ntp.load
+  end
+
+  describe "#load" do
+    context "when there is only one entry of a collection" do
+      let(:content) do
+        "server 127.127.1.0\n"
+      end
+
+      it "fixes the key of the collection" do
+        expect(ntp.records.first.augeas[:key]).to eq("server[]")
+      end
+    end
+  end
+
+  describe "#records" do
+    let(:content) { ntp_disk_content }
+
+    it "obtains the corrent amount of records" do
+      expect(ntp.records.count).to eq(12)
+    end
+
+    it "obtains a collection of records" do
+      expect(ntp.records).to be_a(CFA::NtpConf::RecordCollection)
+    end
+  end
+
+  describe "#save" do
+    let(:content) do
+      "server 0.pool.ntp.org\n" \
+      "server 1.pool.ntp.org\n" \
+      "server 2.pool.ntp.org\n"
+    end
+
+    context "when a record is added" do
+      it "writes a new entry" do
+        record = CFA::NtpConf::ServerRecord.new
+        record.value = "3.pool.ntp.org"
+        ntp.records << record
+        ntp.save
+        expect(file.content.lines).to include("server 3.pool.ntp.org\n")
+      end
+
+      it "writes it together with its options" do
+        record = CFA::NtpConf::ServerRecord.new
+        record.value = "3.pool.ntp.org"
+        record.raw_options = "iburst dynamic"
+        ntp.records << record
+        ntp.save
+        expect(file.content.lines).to include("server 3.pool.ntp.org iburst dynamic\n")
+      end
+
+      it "writes comment from entry" do
+        record = CFA::NtpConf::ServerRecord.new
+        record.value = "3.pool.ntp.org"
+        record.comment = "# test comment"
+        ntp.records << record
+        ntp.save
+        expect(file.content.lines).to include("server 3.pool.ntp.org# test comment\n")
+
+      end
+    end
+
+    context "when a record is deleted" do
+      it "removes an entry" do
+        record = ntp.records.find { |r| r.value == "0.pool.ntp.org" }
+        ntp.records.delete(record)
+        ntp.save
+        expect(file.content.lines).not_to include("server 0.pool.ntp.org\n")
+      end
+    end
+
+    context "when a record is updated" do
+      it "modifies an entry" do
+        record = ntp.records.find { |r| r.value == "0.pool.ntp.org" }
+        record.value = "10.pool.ntp.org"
+        ntp.save
+        expect(file.content.lines).not_to include("server 0.pool.ntp.org\n")
+        expect(file.content.lines).to include("server 10.pool.ntp.org\n")
+      end
+    end
+  end
+end
+
+describe CFA::NtpConf::RecordCollection do
+  let(:ntp) { ntp_conf(file) }
+
+  let(:file) { ntp_file(content) }
+
+  let(:new_record) do
+    record = CFA::NtpConf::ServerRecord.new
+    record.value = "3.pool.ntp.org"
+    record
+  end
+
+  let(:existing_record) { ntp.records.first }
+
+  let(:content) do
+    "server 0.pool.ntp.org\n" \
+    "server 1.pool.ntp.org\n" \
+    "server 2.pool.ntp.org\n"
+  end
+
+  before do
+    ntp.load
+  end
+
+  context "#<<" do
+    context "when does not exist the record to add" do
+      it "adds the record" do
+        ntp.records << new_record
+        expect(ntp.records.count(new_record)).to eq(1)
+      end
+    end
+
+    context "when exists the record to add" do
+      it "adds the record too" do
+        ntp.records << existing_record
+        expect(ntp.records.count(existing_record)).to eq(2)
+      end
+    end
+  end
+
+  context "#delete" do
+    context "when does not exist the record to delete" do
+      it "does anything" do
+        records = ntp.records
+        ntp.records.delete(new_record)
+        expect(ntp.records).to eq(records)
+      end
+    end
+
+    context "when exists the record to delete" do
+      it "deletes the record" do
+        ntp.records.delete(existing_record)
+        expect(ntp.records.include?(existing_record)).to be(false)
+      end
+    end
+  end
+
+  context "#delete_if" do
+    it "deletes all records that satisfy the condition" do
+      ntp.records.delete_if { |record| record.type == "server" }
+      expect(ntp.records.any? { |record| record.type == "server" }).to eq(false)
+    end
+  end
+end
+
+describe CFA::NtpConf::Record do
+  let(:ntp) { ntp_conf(file) }
+
+  let(:file) { ntp_file(content) }
+
+  let(:content) do
+    "server 0.pool.ntp.org iburst\n" \
+    "server 1.pool.ntp.org #sample comment\n" \
+    "server 2.pool.ntp.org\n"
+  end
+
+  before do
+    ntp.load
+  end
+
+  describe ".new_from_augeas" do
+    let(:augeas_element) do
+      {
+        key:   "server[]",
+        value: "3.pool.ntp.org"
+      }
+    end
+
+    subject(:record) { described_class.new_from_augeas(augeas_element) }
+
+    it "creates a record of the correct class" do
+      expect(record).to be_a(CFA::NtpConf::ServerRecord)
+    end
+
+    it "creates the record with correct data" do
+      expect(record.augeas).to eq(augeas_element)
+    end
+  end
+
+  describe "#value" do
+    it "obtains the value of the record" do
+      record = ntp.records.first
+      expect(record.value).to eq("0.pool.ntp.org")
+    end
+  end
+
+  describe "#value=" do
+    it "sets the value of the record" do
+      value = "3.pool.ntp.org"
+      record = ntp.records.first
+      record.value = value
+      expect(record.value).to eq(value)
+      ntp.save
+      expect(file.content).to include("server 3.pool.ntp.org iburst\n")
+    end
+  end
+
+  describe "#comment" do
+    context "when the record has not comment" do
+      it "obtains nil" do
+        record = ntp.records.first
+        expect(record.comment).to eq(nil)
+      end
+    end
+
+    context "when the record has comment" do
+      it "obtains the comment" do
+        record = ntp.records.to_a[1]
+        expect(record.comment).to eq("#sample comment")
+      end
+    end
+  end
+
+  describe "#comment=" do
+    it "sets a comment to the record" do
+      comment = "#sample comment"
+      record = ntp.records.first
+      record.comment = comment
+      expect(record.comment).to eq(comment)
+      ntp.save
+      expect(file.content).to include("server 0.pool.ntp.org iburst#sample comment\n")
+    end
+  end
+
+  describe "#==" do
+    it "returns true for equal records" do
+      record = ntp.records.first
+      expect(record == record.dup).to be(true)
+    end
+
+    it "returns false for different records" do
+      records = ntp.records.to_a
+      expect(records[0] == records[1]).to be(false)
+    end
+  end
+
+  describe "#type" do
+    it "obtains the type of the record" do
+      expect(ntp.records.first.type).to eq("server")
+    end
+  end
+
+  describe "#raw_options" do
+    it "obtains options as string" do
+      expect(ntp.records.first.raw_options).to eq("iburst")
+    end
+  end
+
+  describe "#raw_options=" do
+    it "sets options from a string" do
+      record = ntp.records.first
+      record.raw_options = "iburst prefer"
+      expect(record.options).to eq(["iburst", "prefer"])
+      ntp.save
+      expect(file.content).to include("server 0.pool.ntp.org iburst prefer\n")
+    end
+  end
+end
+
+describe CFA::NtpConf::CommandRecord do
+  let(:ntp) { ntp_conf(file) }
+
+  let(:file) { ntp_file(content) }
+
+  let(:content) do
+    "server 0.pool.ntp.org iburst\n"
+  end
+
+  before do
+    ntp.load
+  end
+
+  subject(:record) { ntp.records.first }
+
+  describe "#options" do
+    it "obtains the options of the record" do
+      expect(record.options).to eq(["iburst"])
+    end
+  end
+
+  describe "#options=" do
+    it "sets options to the record" do
+      record.options = ["iburst", "prefer"]
+      expect(record.options).to eq(["iburst", "prefer"])
+      ntp.save
+      expect(file.content).to include("server 0.pool.ntp.org iburst prefer\n")
+    end
+  end
+end
+
+describe CFA::NtpConf::FudgeRecord do
+  let(:ntp) { ntp_conf(file) }
+
+  let(:file) { ntp_file(content) }
+
+  let(:content) do
+    "fudge 127.127.1.0 stratum 10\n"
+  end
+
+  before do
+    ntp.load
+  end
+
+  subject(:record) { ntp.records.first }
+
+  describe "#options" do
+    it "obtains the options of the record" do
+      expect(record.options).to eq("stratum" => "10")
+    end
+  end
+
+  context "#options=" do
+    it "sets options to the record" do
+      options = { "stratum" => "11" }
+      record.options = options
+      expect(record.options).to eq(options)
+      ntp.save
+      expect(file.content).to include("fudge 127.127.1.0 stratum 11\n")
+    end
+  end
+
+  describe "#raw_options" do
+    it "obtains options as string" do
+      expect(record.raw_options).to eq("stratum 10")
+    end
+  end
+
+  describe "#raw_options=" do
+    it "sets options from a string" do
+      record.raw_options = "stratum 11"
+      expect(record.options).to eq("stratum" => "11")
+      ntp.save
+      expect(file.content).to include("fudge 127.127.1.0 stratum 11\n")
+    end
+  end
+end
+
+describe CFA::NtpConf::RestrictRecord do
+  let(:ntp) { ntp_conf(file) }
+
+  let(:file) { ntp_file(content) }
+
+  let(:content) do
+    "restrict -4 default notrap nomodify nopeer\n"
+  end
+
+  before do
+    ntp.load
+  end
+
+  subject(:record) { ntp.records.first }
+
+  describe "#options" do
+    it "obtains the options of the record" do
+      expect(record.options).to eq(%w(notrap nomodify nopeer))
+    end
+  end
+
+  context "#options=" do
+    it "sets options to the record" do
+      options = ["notrap"]
+      record.options = options
+      expect(record.options).to eq(options)
+      ntp.save
+      expect(file.content).to include("restrict -4 default notrap\n")
+    end
+  end
+
+  describe "#raw_options" do
+    it "obtains options as string" do
+      expect(record.raw_options).to eq("notrap nomodify nopeer")
+    end
+  end
+
+  describe "#raw_options=" do
+    it "sets options from a string" do
+      record.raw_options = "notrap"
+      expect(record.options).to eq(["notrap"])
+      ntp.save
+      expect(file.content).to include("restrict -4 default notrap\n")
+    end
+  end
+end

--- a/test/fixtures/cfa/ntp.conf
+++ b/test/fixtures/cfa/ntp.conf
@@ -1,0 +1,24 @@
+restrict -4 default notrap nomodify nopeer noquery
+restrict -6 default notrap nomodify nopeer noquery
+
+restrict 127.0.0.1
+restrict ::1
+
+driftfile /var/lib/ntp/drift/ntp.drift # path for drift file
+
+logfile   /var/log/ntp		# alternate log file
+
+keys /etc/ntp.keys		# path for keys file
+trustedkey 1			# define trusted keys
+requestkey 1			# key (7) for accessing server variables
+controlkey 1			# key (6) for accessing server variables
+
+server 0.pool.ntp.org
+server 1.pool.ntp.org
+server 2.pool.ntp.org
+server 3.pool.ntp.org
+server 127.127.1.0    # local clock (LCL)
+fudge  127.127.1.0 stratum 10 # LCL is unsynchronized
+
+peer 128.100.0.45
+peer 192.168.1.30


### PR DESCRIPTION
NtpClient does not handle the configuration file properly. The problem is fixed in `master`, but we need to fix also for CaaSP. So I've decided to port (actually to copy) the CFA class (used in master).

This class won't be used by `NtpClient` as there are too many changes involved and I would like to be as conservative as possible at this point.

Of course, CaaSP version will diverge from SLE 12 SP2.