### PR TITLE
Write restrict records first (bsc#983486)

### DIFF
--- a/package/yast2-ntp-client.changes
+++ b/package/yast2-ntp-client.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Fri Jun 30 16:58:16 UTC 2017 - knut.anderssen@suse.com
+
+- Resrict records are written at the end but the default file and
+  most profiles use them at the beginning, which mangles the file
+  completely (bsc#983486).
+  To fix it we have just changed the order of writing.
+- 3.1.29
+
+-------------------------------------------------------------------
 Thu Aug 11 14:24:42 CEST 2016 - schubi@suse.de
 
 - Error while using <type>__clock</type> in AutoYaST.

--- a/package/yast2-ntp-client.spec
+++ b/package/yast2-ntp-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ntp-client
-Version:        3.1.28
+Version:        3.1.29
 Release:        0
 Summary:        YaST2 - NTP Client Configuration
 License:        GPL-2.0+

--- a/src/modules/NtpClient.rb
+++ b/src/modules/NtpClient.rb
@@ -598,6 +598,8 @@ module Yast
       # write settings
       return false if !go_next
 
+      # Restrict map records are written first to not mangle the config file
+      # (bsc#983486)
       @ntp_records = restrict_map_records + @ntp_records
 
       log.info "Writing settings #{@ntp_records}"

--- a/src/modules/NtpClient.rb
+++ b/src/modules/NtpClient.rb
@@ -598,7 +598,7 @@ module Yast
       # write settings
       return false if !go_next
 
-      @ntp_records += restrict_map_records
+      @ntp_records = restrict_map_records + @ntp_records
 
       log.info "Writing settings #{@ntp_records}"
 


### PR DESCRIPTION
Trello card: https://trello.com/c/N9tffDE4/1062-sles12-sp2-p3-983486-yast2-ntp-client-mangles-etc-ntpconf

Default template is something like:

```
# Comment
# Comment
# Comment
restrict -4 default notrap...
restrict -6 default notrap...

pool.ntp.example.org
```

And after read and write it was written as:


```
pool.ntp.example.org
# Comment
# Comment
# Comment
restrict -4 default notrap...
restrict -6 default notrap...
```

This PR just writes the restrict entries before the rest.