### PR TITLE
Permitted the use of 'listentry' element or 'ntp_server' and to be an empty list

### DIFF
--- a/package/yast2-ntp-client.changes
+++ b/package/yast2-ntp-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar 22 08:16:37 UTC 2018 - knut.anderssen@suse.com
+
+- Permitted the use of 'listentry' element or 'ntp_server' and
+  allowed to be an empty list in the AutoYaST schema (bsc#1013047)
+- 4.0.10
+
+-------------------------------------------------------------------
 Wed Mar  7 10:57:36 UTC 2018 - jreidinger@suse.com
 
 - change cron config file name to suse-ntp_synchronize

--- a/package/yast2-ntp-client.spec
+++ b/package/yast2-ntp-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ntp-client
-Version:        4.0.9
+Version:        4.0.10
 Release:        0
 Summary:        YaST2 - NTP Client Configuration
 License:        GPL-2.0+

--- a/src/autoyast-rnc/ntpclient.rnc
+++ b/src/autoyast-rnc/ntpclient.rnc
@@ -18,9 +18,9 @@ ntp_sync = element ntp_sync { text }
 
 ntp_servers = element ntp_servers {
       LIST,
-      element ntp_server {
+      element (ntp_server | listentry) {
         element address { text } &
         element iburst { BOOLEAN }? &
         element offline { BOOLEAN }?
-      }
+      }*
 }


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1013047