### PR TITLE
Do not show the Progress dialog while merging the configuration

### DIFF
--- a/package/yast2-ntp-client.changes
+++ b/package/yast2-ntp-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Oct  3 14:11:34 UTC 2018 - knut.anderssen@suse.com
+
+- AutoYaST: Do not show the progress when merging the configuration
+  before writing it (bsc#1110598)
+- 4.0.13
+
+-------------------------------------------------------------------
 Thu Apr 19 08:56:08 CEST 2018 - schubi@suse.de
 
 - Fix in checking installed chrony package while writing ntp

--- a/package/yast2-ntp-client.spec
+++ b/package/yast2-ntp-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ntp-client
-Version:        4.0.12
+Version:        4.0.13
 Release:        0
 Summary:        YaST2 - NTP Client Configuration
 License:        GPL-2.0+

--- a/src/lib/y2ntp_client/client/auto.rb
+++ b/src/lib/y2ntp_client/client/auto.rb
@@ -39,9 +39,9 @@ module Y2NtpClient
       end
 
       def write
+        progress_orig = Yast::Progress.set(false)
         # ensure to merge config to system chrony configuration to do minimal configuration
         Yast::NtpClient.merge_to_system
-        progress_orig = Yast::Progress.set(false)
         Yast::NtpClient.write_only = true
         ret = Yast::NtpClient.Write
         Yast::Progress.set(progress_orig)


### PR DESCRIPTION
When the AutoYaST configuration changes are applied and the configuration is read, the read process dialog is not closed once finished

![screenshot from 2018-10-01 10-52-04](https://user-images.githubusercontent.com/7056681/46416325-357b8080-c71f-11e8-8eb5-7d7560034bce.png)

So we have just set it to not be visible not only for writing but also for merging as we already do for reading.
