### PR TITLE
Only sync ui

### DIFF
--- a/package/yast2-ntp-client.changes
+++ b/package/yast2-ntp-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Nov 14 21:32:26 UTC 2018 - knut.andersse@suse.com
+
+- Aligned "Synchronize Now" button and "NTP Server Address" box not
+  breaking previous fix (bnc#893065, bsc#1039985)
+- 4.0.16
+
+-------------------------------------------------------------------
 Thu Nov  8 19:20:26 UTC 2018 - knut.andersse@suse.com
 
 - fate#323454

--- a/package/yast2-ntp-client.changes
+++ b/package/yast2-ntp-client.changes
@@ -2,7 +2,8 @@
 Wed Nov 14 21:32:26 UTC 2018 - knut.andersse@suse.com
 
 - Aligned "Synchronize Now" button and "NTP Server Address" box not
-  breaking previous fix (bnc#893065, bsc#1039985)
+  breaking previous fix and not hiding the manual checkbox in
+  TextMode (bnc#893065, bsc#1039985).
 - 4.0.16
 
 -------------------------------------------------------------------

--- a/package/yast2-ntp-client.spec
+++ b/package/yast2-ntp-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ntp-client
-Version:        4.0.15
+Version:        4.0.16
 Release:        0
 Summary:        YaST2 - NTP Client Configuration
 License:        GPL-2.0+

--- a/src/clients/ntp-client_proposal.rb
+++ b/src/clients/ntp-client_proposal.rb
@@ -226,7 +226,7 @@ module Yast
           HWeight(
             1,
             VBox(
-              VSpacing(1),
+              UI.TextMode ? VSpacing(1) : Label(""),
               # push button label
               Left(PushButton(Id(:ntp_now), _("S&ynchronize now")))
             )

--- a/src/clients/ntp-client_proposal.rb
+++ b/src/clients/ntp-client_proposal.rb
@@ -218,7 +218,7 @@ module Yast
               ComboBox(
                 Id(:ntp_address),
                 Opt(:editable, :hstretch),
-                # combo box label
+                # TRANSLATORS: combo box label
                 _("&NTP Server Address")
               )
             )
@@ -226,8 +226,11 @@ module Yast
           HWeight(
             1,
             VBox(
+              # In TextMode and empty label is not filling an extra space, so
+              # an explicit vertical space was added in order to move down the
+              # push button being aligned with the combo box input.
               UI.TextMode ? VSpacing(1) : Label(""),
-              # push button label
+              # TRANSLATORS: push button label
               Left(PushButton(Id(:ntp_now), _("S&ynchronize now")))
             )
           )
@@ -250,7 +253,7 @@ module Yast
               ),
               HBox(
                 HSpacing(0.5),
-                # check box label
+                # TRANSLATORS: check box label
                 Left(
                   CheckBox(Id(:ntp_save), _("&Save NTP Configuration"), true)
                 )
@@ -260,7 +263,7 @@ module Yast
           HWeight(
             1,
             VBox(
-              # push button label
+              # TRANSLATORS: push button label
               # bnc#449615: only simple config for inst-sys
               Stage.initial ? Label("") : Left(PushButton(Id(:ntp_configure), _("&Configure..."))),
               Label("")

--- a/src/clients/ntp-client_proposal.rb
+++ b/src/clients/ntp-client_proposal.rb
@@ -214,17 +214,29 @@ module Yast
           HSpacing(3),
           HWeight(
             1,
+            Left(
+              ComboBox(
+                Id(:ntp_address),
+                Opt(:editable, :hstretch),
+                # combo box label
+                _("&NTP Server Address")
+              )
+            )
+          ),
+          HWeight(
+            1,
             VBox(
-              VSpacing(0.5),
-              Left(
-                ComboBox(
-                  Id(:ntp_address),
-                  Opt(:editable, :hstretch),
-                  # combo box label
-                  _("&NTP Server Address")
-                )
-              ),
-              VSpacing(0.3),
+              VSpacing(1),
+              # push button label
+              Left(PushButton(Id(:ntp_now), _("S&ynchronize now")))
+            )
+          )
+        ),
+        HBox(
+          HSpacing(3),
+          HWeight(
+            1,
+            VBox(
               HBox(
                 HSpacing(0.5),
                 # check box label
@@ -248,10 +260,6 @@ module Yast
           HWeight(
             1,
             VBox(
-              Label(""),
-              # push button label
-              Left(PushButton(Id(:ntp_now), _("S&ynchronize now"))),
-              VSpacing(0.3),
               # push button label
               # bnc#449615: only simple config for inst-sys
               Stage.initial ? Label("") : Left(PushButton(Id(:ntp_configure), _("&Configure..."))),


### PR DESCRIPTION
Fix for [bsc#1039985](https://bugzilla.suse.com/show_bug.cgi?id=1039985), in previous attempt [bsc#893065](https://bugzilla.suse.com/show_bug.cgi?id=893065) it was fixed in SLE but broken in openSUSE.

## OpenSUSE

![opensuseinstallation](https://user-images.githubusercontent.com/7056681/48695334-d4c4dc00-ebd6-11e8-8b09-a75a50eb9970.png)

## SLES

![slesinst](https://user-images.githubusercontent.com/7056681/48695345-d7bfcc80-ebd6-11e8-93ce-cd281813d039.png)

## Textmode

![slesinsttext](https://user-images.githubusercontent.com/7056681/48695353-dc848080-ebd6-11e8-92fb-ad2c0411ef87.png)

## In a running system

![screenshot from 2018-11-20 09-21-20](https://user-images.githubusercontent.com/7056681/48763729-c8f41b00-eca5-11e8-87c4-ca6c1fdd8cb0.png)
![screenshot from 2018-11-20 09-21-17](https://user-images.githubusercontent.com/7056681/48763731-c8f41b00-eca5-11e8-9e4f-9a993a134c2c.png)
![running](https://user-images.githubusercontent.com/7056681/48695950-700a8100-ebd8-11e8-9a2e-f16d0d11eb98.png)
![installationstylerunning](https://user-images.githubusercontent.com/7056681/48695953-71d44480-ebd8-11e8-832e-6d7e866ee19a.png)