### PR TITLE
Fix/ntp client return value

### DIFF
--- a/package/yast2-ntp-client.changes
+++ b/package/yast2-ntp-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul  4 10:29:27 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix 'ntp-client' behaviour when running in firstboot
+  (bsc#1140199). 
+- 4.0.18
+
+-------------------------------------------------------------------
 Fri Mar  8 14:39:23 UTC 2019 - knut.anderssen@suse.com
 
 - Added cwm/popup dependency (bsc#893065, bsc#1039985)

--- a/package/yast2-ntp-client.spec
+++ b/package/yast2-ntp-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ntp-client
-Version:        4.0.17
+Version:        4.0.18
 Release:        0
 Summary:        YaST2 - NTP Client Configuration
 License:        GPL-2.0+

--- a/src/clients/ntp-client.rb
+++ b/src/clients/ntp-client.rb
@@ -8,6 +8,9 @@
 # $Id$
 #
 # Main file for ntp-client configuration. Uses all other files.
+
+Yast.import "Stage"
+
 module Yast
   class NtpClientClient < Client
     def main
@@ -43,9 +46,11 @@ module Yast
     end
 
     # CommandLine handler for running GUI
-    # @return [Boolean] true if settings were saved
+    # @return [Boolean,Symbol] true if settings were saved; :next, :abort or :back
+    #   when running in 'firstboot'
     def GuiHandler
       ret = NtpClientSequence()
+      return ret if Yast::Stage.firstboot
       return false if ret == :abort || ret == :back || ret.nil?
       true
     end

--- a/src/lib/y2ntp_client/dialog/main.rb
+++ b/src/lib/y2ntp_client/dialog/main.rb
@@ -5,7 +5,7 @@ require "y2ntp_client/widgets/main_widgets"
 
 Yast.import "Label"
 Yast.import "NtpClient"
-Yast.import "Stage"
+Yast.import "Mode"
 
 module Y2NtpClient
   module Dialog
@@ -55,7 +55,8 @@ module Y2NtpClient
       end
 
       def abort_button
-        Yast::Label.CancelButton
+        return Yast::Label.CancelButton unless installation?
+        nil
       end
 
       def hardware_clock_widgets
@@ -70,13 +71,23 @@ module Y2NtpClient
       end
 
       def back_button
-        # no back button
-        ""
+        return "" unless installation?
+        nil
       end
 
       def next_button
-        # FIXME: it probably cannot run in initial stage, so not needed
-        Yast::Stage.initial ? Yast::Label.AcceptButton : Yast::Label.OKButton
+        return Yast::Label.OKButton unless installation?
+        nil
+      end
+
+      # Determines whether running in installation mode
+      #
+      # We do not use Stage.initial because of firstboot, which which runs in 'installation' mode
+      # but in 'firstboot' stage.
+      #
+      # @return [Boolean] Boolean if running in installation or update mode
+      def installation?
+        Yast::Mode.installation || Yast::Mode.update
       end
     end
   end


### PR DESCRIPTION
This PR fixes [1140199](https://bugzilla.suse.com/show_bug.cgi?id=1140199) by adjusting `ntp-client` behavior when running in firstboot stage:

* OK/Cancel buttons are replaced by Next/Cancel/Abort
* It returns a symbol instead of true/false

## Normal mode:
![screenshot-ntp-client](https://user-images.githubusercontent.com/15836/60661214-6b39cb00-9e51-11e9-8428-65fe802df6e2.png)

## Firstboot:

![screenshot-ntp-client-firstboot](https://user-images.githubusercontent.com/15836/60661227-71c84280-9e51-11e9-9902-c7613154b31e.png)

## AutoYaST UI:

![screenshot-ntp-client-autoyast-config](https://user-images.githubusercontent.com/15836/60661244-77be2380-9e51-11e9-9dd0-851155bd531d.png)
