### PR TITLE
Fixed saving /etc/ntp.conf with certain comments (bsc#1142026)

### DIFF
--- a/package/yast2-ntp-client.changes
+++ b/package/yast2-ntp-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Aug 02 15:16:17 CEST 2019 - aschnell@suse.com
+
+- Fixed saving /etc/ntp.conf with certain comments (bsc#1142026)
+- 3.2.19
+
+-------------------------------------------------------------------
 Thu Dec 13 12:45:27 UTC 2018 - knut.anderssen@suse.com
 
 - Fixed sync_once method return value (bsc#1108497)

--- a/package/yast2-ntp-client.spec
+++ b/package/yast2-ntp-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ntp-client
-Version:        3.2.18
+Version:        3.2.19
 Release:        0
 Summary:        YaST2 - NTP Client Configuration
 License:        GPL-2.0+

--- a/src/lib/cfa/ntp_conf.rb
+++ b/src/lib/cfa/ntp_conf.rb
@@ -97,8 +97,8 @@ module CFA
         comments = r.augeas[:multiline].split("\n")
         matcher = Matcher.new(key: r.augeas[:key], value_matcher: r.augeas[:value])
         placer = BeforePlacer.new(matcher)
-        comments.each do |c|
-          data.add("#comment[]", c, placer)
+        comments.each do |comment|
+          data.add("#comment[]", comment.strip, placer)
         end
       end
       super

--- a/src/modules/NtpClient.rb
+++ b/src/modules/NtpClient.rb
@@ -1021,7 +1021,8 @@ module Yast
     # Remove blank spaces in values
     #
     # @note to avoid augeas parsing errors, comments should be sanitized by
-    #   removing blank spaces at the beginning and adding line break.
+    #   removing blank spaces at the beginning and adding line break. Further
+    #   sanitation is done in NtpConf.save.
     def sanitize_record(record)
       sanitized = record.dup
       sanitized.each do |key, value|

--- a/test/cfa/ntp_conf_test.rb
+++ b/test/cfa/ntp_conf_test.rb
@@ -94,6 +94,19 @@ describe CFA::NtpConf do
         expect(file.content.lines).to include("#test comment 2\n")
         expect(file.content.lines).to include("#test comment3\n")
       end
+
+      # see bsc #1142026
+      it "can write multi lines comments with unstripped whitespaces from autoyast profiles" do
+        record = CFA::NtpConf::ServerRecord.new
+        record.value = "4.pool.ntp.org"
+        record.comment = " test comment 4 \n \n test comment 5 "
+        ntp.records << record
+        expect(record.comment).to eq " test comment 4 \n \n test comment 5 "
+        ntp.save
+        expect(file.content.lines).to include("#test comment 4\n")
+        expect(file.content.lines).to include("#test comment 5\n")
+        expect(file.content.lines).to include("server 4.pool.ntp.org\n")
+      end
     end
 
     context "when a record is deleted" do


### PR DESCRIPTION
For https://trello.com/c/GA5jJ2a7/1188-3-sles12-sp5-p2-1142026-augeas-parsing-serializing-error-when-ntp-client-configuration-is-specified-in-autoyast-control-file.