### PR TITLE
AutoYaST: sanitize comments when importing

### DIFF
--- a/package/yast2-ntp-client.changes
+++ b/package/yast2-ntp-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug 19 12:04:19 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- AutoYaST: improve importing when a comment contains empty lines.
+- This also fixes bsc#1142026.
+- 3.2.20
+
+-------------------------------------------------------------------
 Fri Aug 02 15:16:17 CEST 2019 - aschnell@suse.com
 
 - Fixed saving /etc/ntp.conf with certain comments (bsc#1142026)

--- a/package/yast2-ntp-client.spec
+++ b/package/yast2-ntp-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ntp-client
-Version:        3.2.19
+Version:        3.2.20
 Release:        0
 Summary:        YaST2 - NTP Client Configuration
 License:        GPL-2.0+

--- a/src/lib/cfa/ntp_conf.rb
+++ b/src/lib/cfa/ntp_conf.rb
@@ -98,7 +98,7 @@ module CFA
         matcher = Matcher.new(key: r.augeas[:key], value_matcher: r.augeas[:value])
         placer = BeforePlacer.new(matcher)
         comments.each do |comment|
-          data.add("#comment[]", comment.strip, placer)
+          data.add("#comment[]", comment, placer)
         end
       end
       super

--- a/test/cfa/ntp_conf_test.rb
+++ b/test/cfa/ntp_conf_test.rb
@@ -94,19 +94,6 @@ describe CFA::NtpConf do
         expect(file.content.lines).to include("#test comment 2\n")
         expect(file.content.lines).to include("#test comment3\n")
       end
-
-      # see bsc #1142026
-      it "can write multi lines comments with unstripped whitespaces from autoyast profiles" do
-        record = CFA::NtpConf::ServerRecord.new
-        record.value = "4.pool.ntp.org"
-        record.comment = " test comment 4 \n \n test comment 5 "
-        ntp.records << record
-        expect(record.comment).to eq " test comment 4 \n \n test comment 5 "
-        ntp.save
-        expect(file.content.lines).to include("#test comment 4\n")
-        expect(file.content.lines).to include("#test comment 5\n")
-        expect(file.content.lines).to include("server 4.pool.ntp.org\n")
-      end
     end
 
     context "when a record is deleted" do

--- a/test/fixtures/autoyast/autoinst.xml
+++ b/test/fixtures/autoyast/autoinst.xml
@@ -13,7 +13,11 @@
       </peer>
       <peer>
         <address>1.opensuse.pool.ntp.org</address>
-        <comment/>
+        <comment> # a comment with spaces
+
+          # and blank lines
+
+        </comment>
         <options>iburst</options>
         <type>server</type>
       </peer>

--- a/test/ntp_client_test.rb
+++ b/test/ntp_client_test.rb
@@ -61,6 +61,12 @@ describe Yast::NtpClient do
           expect(record["comment"]).to eq "# a comment with spaces \n"
         end
 
+        # see bsc #1142026
+        it "sanitizes comments by removing blank lines" do
+          record = subject.ntp_records[1]
+          expect(record["comment"]).to eq "# a comment with spaces\n# and blank lines\n"
+        end
+
         it "reads the list of peers" do
           expect(subject.ntp_records.size).to eq 5
         end
@@ -147,7 +153,16 @@ describe Yast::NtpClient do
 
       it "produces an output equivalent to #Import" do
         subject.Import(ntp_client_section)
-        expect(subject.Export()).to eq ntp_client_section
+
+        result = subject.Export
+
+        expect(result["synchronize_time"]).to eq(ntp_client_section["synchronize_time"])
+        expect(result["sync_interval"]).to eq(ntp_client_section["sync_interval"])
+        expect(result["start_at_boot"]).to eq(ntp_client_section["start_at_boot"])
+        expect(result["start_in_chroot"]).to eq(ntp_client_section["start_in_chroot"])
+        expect(result["ntp_policy"]).to eq(ntp_client_section["ntp_policy"])
+        expect(result["peers"].size).to eq(ntp_client_section["peers"].size)
+        expect(result["restricts"].size).to eq(ntp_client_section["restricts"].size)
       end
 
       it "clones without encountering a CFA object" do


### PR DESCRIPTION
### Problem

When an imported AutoYaST profile specifies an NTP entry where the comment contains empty lines, the Augeas parser fails when trying to save the `/etc/ntp.conf` file.

```
      <peer>
        <address>1.opensuse.pool.ntp.org</address>
        <comment> # a comment with spaces

          # and blank lines

        </comment>
        <options>iburst</options>
        <type>server</type>
      </peer>
```

*  https://bugzilla.suse.com/show_bug.cgi?id=1142026

### Solution

This was already fixed by https://github.com/yast/yast-ntp-client/pull/143. IMHO, the problem with that solution is that we are delegating the responsibility of fixing the imported record to the method `NtpConf#save`.

This new solution moves such responsibility to the `sanitizer` method that already exists. This sanitizer is called during the AutoYaST importation. 

### Tests

* Added unit tests
* Manually tested