### PR TITLE
don't use /bin/systemctl compat symlink (bsc#1160890)

### DIFF
--- a/package/yast2-ntp-client.changes
+++ b/package/yast2-ntp-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 23 12:58:04 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- don't use /bin/systemctl compat symlink (bsc#1160890)
+- 4.2.7
+
+-------------------------------------------------------------------
 Thu Nov 14 13:32:05 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - Break autoyast<->yast2-ntp-client cycle (related to changes done

--- a/package/yast2-ntp-client.spec
+++ b/package/yast2-ntp-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ntp-client
-Version:        4.2.6
+Version:        4.2.7
 Release:        0
 Summary:        YaST2 - NTP Client Configuration
 License:        GPL-2.0-or-later

--- a/package/yast2-ntp-client.spec
+++ b/package/yast2-ntp-client.spec
@@ -83,8 +83,8 @@ fi
 # jsc#SLE-9113
 if [ -f /etc/cron.d/suse-ntp_synchronize ]; then
   /usr/bin/erb timeout=$(grep -o '[[:digit:]]\+' /etc/cron.d/suse-ntp_synchronize) /usr/share/YaST2/data/yast-timesync.timer.erb > /etc/systemd/system/yast-timesync.timer
-  /bin/systemctl enable yast-timesync.timer
-  /bin/systemctl start yast-timesync.timer
+  /usr/bin/systemctl enable yast-timesync.timer
+  /usr/bin/systemctl start yast-timesync.timer
   rm /etc/cron.d/suse-ntp_synchronize
 fi
 


### PR DESCRIPTION
## Problem

https://bugzilla.suse.com/show_bug.cgi?id=1160890
https://trello.com/c/3Y9HSV8m

`/bin/systemctl` symlink is gone.

## Solution

Don't use it.