### PR TITLE
[SLE-7188] Default to SUSE NTP servers

### DIFF
--- a/package/yast2-ntp-client.changes
+++ b/package/yast2-ntp-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 19 13:24:06 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Rely on the new Y2Network::NtpServer class (jsc#SLE-7188).
+- 4.2.8
+
+-------------------------------------------------------------------
 Thu Jan 23 12:58:04 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
 
 - don't use /bin/systemctl compat symlink (bsc#1160890)

--- a/package/yast2-ntp-client.spec
+++ b/package/yast2-ntp-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ntp-client
-Version:        4.2.7
+Version:        4.2.8
 Release:        0
 Summary:        YaST2 - NTP Client Configuration
 License:        GPL-2.0-or-later
@@ -39,6 +39,8 @@ BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  rubygem(%rb_default_ruby_abi:cfa) >= 0.6.0
 BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
+# Y2Network::NtpServer
+BuildRequires:  yast2-network >= 4.2.55
 
 # proper acting TargetFile when scr is switched
 Requires:       augeas-lenses
@@ -46,8 +48,8 @@ Requires:       augeas-lenses
 Requires:       yast2 >= 4.1.15
 Requires:       yast2-country-data
 # needed for network/config agent
-# Yast::Lan.dhcp_ntp_servers
-Requires:       yast2-network >= 4.1.17
+# Y2Network::NtpServer
+Requires:       yast2-network >= 4.2.55
 Requires:       yast2-ruby-bindings >= 1.0.0
 Requires:       rubygem(%rb_default_ruby_abi:cfa) >= 0.6.0
 

--- a/src/clients/ntp-client_proposal.rb
+++ b/src/clients/ntp-client_proposal.rb
@@ -491,7 +491,12 @@ module Yast
     # @return [Array<Yast::Term>] ntp address Item
     def timezone_ntp_items
       timezone_country = Timezone.GetCountryForTimezone(Timezone.timezone)
-      NtpClient.GetNtpServersByCountry(timezone_country, true)
+      servers = NtpClient.country_ntp_servers(timezone_country)
+      # Select the first occurrence of pool.ntp.org as the default option (bnc#940881)
+      selected = servers.find { |s| s.hostname.end_with?("pool.ntp.org") }
+      servers.map do |server|
+        Item(Id(server.hostname), server.hostname, server.hostname == selected)
+      end
     end
 
     # List of dhcp ntp servers Yast::Term items with the ntp address ID and
@@ -499,7 +504,7 @@ module Yast
     #
     # @return [Array<Yast::Term>] ntp address table Item
     def dhcp_ntp_items
-      NtpClient.dhcp_ntp_servers.map { |s| Item(Id(s), s) }
+      NtpClient.dhcp_ntp_servers.map { |s| Item(Id(s.hostname), s.hostname) }
     end
 
     # List of ntp servers Yast::Term items with the ntp address ID and label

--- a/src/lib/y2ntp_client/widgets/pool_widgets.rb
+++ b/src/lib/y2ntp_client/widgets/pool_widgets.rb
@@ -308,8 +308,15 @@ module Y2NtpClient
 
     private
 
+      # Returns the country for the given address
+      #
+      # FIXME: if the UI used a proper object instead of just a string, this
+      # method will not be needed.
+      #
+      # @param address [String] Server address
       def country_for(address)
-        Yast::NtpClient.GetNtpServers.fetch(address, {})["country"]
+        server = Yast::NtpClient.public_ntp_servers.find { |s| s.hostname == address }
+        server ? server.country : nil
       end
     end
 
@@ -382,7 +389,7 @@ module Y2NtpClient
 
       # macro seeItemsSelection
       def items
-        ntp_servers.map { |s, v| [s, "#{s} (#{v["country"]})"] }
+        ntp_servers.map { |s| [s.hostname, "#{s.hostname} (#{s.country})"] }
       end
 
       def refresh(country)
@@ -393,10 +400,10 @@ module Y2NtpClient
     private
 
       def ntp_servers
-        servers = Yast::NtpClient.GetNtpServers
+        servers = Yast::NtpClient.public_ntp_servers
         return servers if @country.to_s.empty?
 
-        servers.find_all { |_s, v| v["country"] == @country }
+        servers.select { |s| s.country == @country }
       end
     end
   end

--- a/src/modules/NtpClient.rb
+++ b/src/modules/NtpClient.rb
@@ -624,7 +624,7 @@ module Yast
     # Convenience method to obtain the list of ntp servers proposed by DHCP
     # @see https://www.rubydoc.info/github/yast/yast-network/Yast/LanClass:${0}
     def dhcp_ntp_servers
-      Yast::Lan.dhcp_ntp_servers
+      Yast::Lan.dhcp_ntp_servers.map { |s| Y2Network::NtpServer.new(s) }
     end
 
     publish variable: :AbortFunction, type: "boolean ()"

--- a/src/modules/NtpClient.rb
+++ b/src/modules/NtpClient.rb
@@ -14,6 +14,7 @@ require "yast2/target_file" # required to cfa work on changed scr
 require "ui/text_helpers"
 require "erb"
 require "yast2/systemctl"
+require "y2network/ntp_server"
 
 module Yast
   class NtpClientClass < Module
@@ -193,7 +194,35 @@ module Yast
       }
     end
 
+    # Returns the know ntp servers
+    #
+    # @return [Array<Y2Network::NtpServer>] Known NTP servers
+    def public_ntp_servers
+      update_ntp_servers! if @ntp_servers.nil?
+      @ntp_servers.values.map do |srv|
+        Y2Network::NtpServer.new(
+          srv["address"], country: srv["country"], location: srv["location"]
+        )
+      end
+    end
+
+    # Returns the NTP servers for the given country
+    #
+    # @param country [String] Country code
+    # @return [Array<Y2Network::NtpServer>] NTP servers for the given country
+    def country_ntp_servers(country)
+      normalized_country = country.upcase
+      servers = public_ntp_servers.select { |s| s.country.upcase == normalized_country }
+      # bnc#458917 add country, in case data/country.ycp does not have it
+      country_server = make_country_ntp_server(country)
+      unless servers.map(&:hostname).include?(country_server.hostname)
+        servers << country_server
+      end
+      servers
+    end
+
     # Get the list of known NTP servers
+    # @deprecated Use public_ntp_servers instead
     # @return a list of known NTP servers
     def GetNtpServers
       update_ntp_servers! if @ntp_servers.nil?
@@ -219,9 +248,11 @@ module Yast
     end
 
     # Get list of public NTP servers for a country
+    #
     # @param [String] country two-letter country code
     # @param [Boolean] terse_output display additional data (location etc.)
     # @return [Array] of servers (usable as combo-box items)
+    # @deprecated Use public_ntp_servers_by_country instead
     def GetNtpServersByCountry(country, terse_output)
       country_names = {}
       servers = GetNtpServers()
@@ -919,6 +950,7 @@ module Yast
     # @return [Array <Hash>] pool records for given countries
     def pool_servers_for(known_countries)
       known_countries.map do |short_country, country_name|
+        # bnc#458917 add country, in case data/country.ycp does not have it
         MakePoolRecord(short_country, country_name)
       end
     end
@@ -944,6 +976,15 @@ module Yast
       width = displayinfo["TextMode"] ? displayinfo.fetch("Width", 80) : 80
 
       Yast::Report.Error(wrap_text(msg, width - 4))
+    end
+
+    # Pool server for the given country
+    #
+    # @param country [String] Country code
+    # @return [Y2Network::NtpServer]
+    def make_country_ntp_server(country)
+      record = MakePoolRecord(country, "")
+      Y2Network::NtpServer.new(record["address"], country: record["country"])
     end
   end
 

--- a/src/modules/NtpClient.rb
+++ b/src/modules/NtpClient.rb
@@ -215,9 +215,7 @@ module Yast
       servers = public_ntp_servers.select { |s| s.country.upcase == normalized_country }
       # bnc#458917 add country, in case data/country.ycp does not have it
       country_server = make_country_ntp_server(country)
-      unless servers.map(&:hostname).include?(country_server.hostname)
-        servers << country_server
-      end
+      servers << country_server unless servers.map(&:hostname).include?(country_server.hostname)
       servers
     end
 

--- a/test/data/ntp_servers_sample.yml
+++ b/test/data/ntp_servers_sample.yml
@@ -1,0 +1,16 @@
+---
+
+- access_policy: open access
+  address: ntp.cgi.cz
+  country: CZ
+  exact_location: Prague, The Czech Republic
+  location: Czech Republic
+  stratum: '2'
+  synchronization: NTP V4 secondary (stratum 2), PC/FreebSD
+
+- address: tick.fh-augsburg.de
+  country: DE
+  exact_location: Augsburg University of Applied Sciences (FH), Augsburg, Bavaria,
+    Germany
+  stratum: '2'
+  synchronization: NTP V3 secondary (stratum 2), i486/Linux

--- a/test/ntp_client_proposal_test.rb
+++ b/test/ntp_client_proposal_test.rb
@@ -19,12 +19,12 @@ describe Yast::NtpClientProposalClient do
     before do
       allow(Yast::Lan).to receive(:dhcp_ntp_servers)
         .and_return(dhcp_ntp_servers)
-     allow(Yast::Directory).to receive(:find_data_file).and_call_original
-     allow(Yast::Directory).to receive(:find_data_file).with("ntp_servers.yml")
-       .and_return(DATA_PATH.join("ntp_servers_sample.yml").to_s)
-     allow(Yast::Timezone).to receive(:timezone).and_return("Europe/Berlin")
-     allow(Yast::Timezone).to receive(:GetCountryForTimezone)
-       .with("Europe/Berlin").and_return("de")
+      allow(Yast::Directory).to receive(:find_data_file).and_call_original
+      allow(Yast::Directory).to receive(:find_data_file).with("ntp_servers.yml")
+        .and_return(DATA_PATH.join("ntp_servers_sample.yml").to_s)
+      allow(Yast::Timezone).to receive(:timezone).and_return("Europe/Berlin")
+      allow(Yast::Timezone).to receive(:GetCountryForTimezone)
+        .with("Europe/Berlin").and_return("de")
     end
 
     context "when NTP servers were found via DHCP" do

--- a/test/ntp_client_proposal_test.rb
+++ b/test/ntp_client_proposal_test.rb
@@ -15,16 +15,22 @@ describe Yast::NtpClientProposalClient do
 
   describe "#MakeProposal" do
     let(:dhcp_ntp_servers) { [] }
+    let(:config_was_read?) { false }
+    let(:ntp_was_selected?) { false }
 
     before do
       allow(Yast::Lan).to receive(:dhcp_ntp_servers)
         .and_return(dhcp_ntp_servers)
-      allow(Yast::Directory).to receive(:find_data_file).and_call_original
-      allow(Yast::Directory).to receive(:find_data_file).with("ntp_servers.yml")
-        .and_return(DATA_PATH.join("ntp_servers_sample.yml").to_s)
+
+      allow(Yast::NtpClient).to receive(:country_ntp_servers).with("de")
+        .and_return([Y2Network::NtpServer.new("de.pool.ntp.org")])
       allow(Yast::Timezone).to receive(:timezone).and_return("Europe/Berlin")
       allow(Yast::Timezone).to receive(:GetCountryForTimezone)
         .with("Europe/Berlin").and_return("de")
+      allow(Yast::NtpClient).to receive(:config_has_been_read).and_return(config_was_read?)
+      allow(Yast::NtpClient).to receive(:ntp_selected).and_return(ntp_was_selected?)
+      allow(Yast::NtpClient).to receive(:GetUsedNtpServers)
+        .and_return(["2.opensuse.pool.ntp.org"])
     end
 
     context "when NTP servers were found via DHCP" do
@@ -49,9 +55,33 @@ describe Yast::NtpClientProposalClient do
         expect(Yast::UI).to receive(:ChangeWidget) do |*args|
           items = args.last
           hostnames = items.map { |i| i[1] }
-          expect(hostnames).to eq(
-            ["tick.fh-augsburg.de", "de.pool.ntp.org"]
-          )
+          expect(hostnames).to eq(["de.pool.ntp.org"])
+        end
+        subject.MakeProposal
+      end
+    end
+
+    context "when the NTP configuration has been read (from chrony)" do
+      let(:config_was_read?) { true }
+
+      it "proposes the known public servers for the current timezone" do
+        expect(Yast::UI).to receive(:ChangeWidget) do |*args|
+          items = args.last
+          hostnames = items.map { |i| i[1] }
+          expect(hostnames).to eq(["2.opensuse.pool.ntp.org"])
+        end
+        subject.MakeProposal
+      end
+    end
+
+    context "when the NTP server was already selected" do
+      let(:ntp_was_selected?) { true }
+
+      it "proposes the known public servers for the current timezone" do
+        expect(Yast::UI).to receive(:ChangeWidget) do |*args|
+          items = args.last
+          hostnames = items.map { |i| i[1] }
+          expect(hostnames).to eq(["2.opensuse.pool.ntp.org"])
         end
         subject.MakeProposal
       end

--- a/test/ntp_client_test.rb
+++ b/test/ntp_client_test.rb
@@ -340,6 +340,38 @@ describe Yast::NtpClient do
     end
   end
 
+  describe "#public_ntp_servers" do
+    before do
+      allow(subject).to receive(:GetAllKnownCountries)
+        .and_return("DE" => "Germany", "CZ" => "Czech Republic")
+      allow(Yast::Directory).to receive(:find_data_file).with("ntp_servers.yml")
+        .and_return(DATA_PATH.join("ntp_servers_sample.yml").to_s)
+    end
+
+    it "returns the list of public NTP servers including the default one for each country" do
+      servers = subject.public_ntp_servers
+      expect(servers.map(&:hostname)).to eq(
+        ["ntp.cgi.cz", "tick.fh-augsburg.de", "de.pool.ntp.org", "cz.pool.ntp.org"]
+      )
+    end
+  end
+
+  describe "#country_ntp_servers" do
+    before do
+      allow(subject).to receive(:GetAllKnownCountries)
+        .and_return("DE" => "Germany", "CZ" => "Czech Republic")
+      allow(Yast::Directory).to receive(:find_data_file).with("ntp_servers.yml")
+        .and_return(DATA_PATH.join("ntp_servers_sample.yml").to_s)
+    end
+
+    it "returns the list of public NTP servers for the given country" do
+      servers = subject.country_ntp_servers("DE")
+      expect(servers.map(&:hostname)).to eq(
+        ["tick.fh-augsburg.de", "de.pool.ntp.org"]
+      )
+    end
+  end
+
   describe "#MakePoolRecord" do
     let(:record) do
       {

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,7 +28,12 @@ def stub_module(name, fake_class = nil)
 end
 
 # stub classes from other modules to speed up a build
-stub_module("Lan", Class.new { def dhcp_ntp_servers; []; end })
+lan = Class.new do
+  def dhcp_ntp_servers
+    []
+  end
+end
+stub_module("Lan", lan)
 stub_module("Language")
 stub_module("Pkg")
 stub_module("PackageCallbacks")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,10 @@ ENV["LC_ALL"] = "en_US.utf8"
 require "yast"
 require "yast/rspec"
 require "yaml"
+require "pathname"
+
+TESTS_PATH = Pathname.new(File.dirname(__FILE__))
+DATA_PATH = TESTS_PATH.join("data")
 
 RSpec.configure do |config|
   config.mock_with :rspec do |mocks|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,12 +22,13 @@ end
 
 # stub module to prevent its Import
 # Useful for modules from different yast packages, to avoid build dependencies
-def stub_module(name)
-  Yast.const_set(name.to_sym, Class.new { def self.fake_method; end })
+def stub_module(name, fake_class = nil)
+  fake_class = Class.new { def self.fake_method; end } if fake_class.nil?
+  Yast.const_set name.to_sym, fake_class
 end
 
 # stub classes from other modules to speed up a build
-stub_module("Lan")
+stub_module("Lan", Class.new { def dhcp_ntp_servers; []; end })
 stub_module("Language")
 stub_module("Pkg")
 stub_module("PackageCallbacks")


### PR DESCRIPTION
Use the new `Y2Network::NtpServer` when proposing the default values for NTP servers.

Related PR: https://github.com/yast/yast-network/pull/1039