### PR TITLE
Supporting more than one ntp server in the time setting module.

### DIFF
--- a/package/yast2-ntp-client.changes
+++ b/package/yast2-ntp-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar  3 16:38:54 CET 2020 - schubi@suse.de
+
+- Supporting more than one ntp server in the time setting module.
+  (bsc#1164547)
+- 4.1.10
+
+-------------------------------------------------------------------
 Thu Jul  4 10:29:27 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix 'ntp-client' behaviour when running in firstboot

--- a/package/yast2-ntp-client.spec
+++ b/package/yast2-ntp-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ntp-client
-Version:        4.1.9
+Version:        4.1.10
 Release:        0
 Summary:        YaST2 - NTP Client Configuration
 License:        GPL-2.0-or-later

--- a/src/clients/ntp-client_proposal.rb
+++ b/src/clients/ntp-client_proposal.rb
@@ -384,7 +384,7 @@ module Yast
 
       return :success if params["write_only"]
 
-      # Only if network is running and user has selected an ntp server try to synchronize
+      # Only if network is running try to synchronize
       # the ntp server.
       if NetworkService.isNetworkRunning && !Service.Active(NtpClient.service_name)
         if !select_ntp_server && ntp_server.empty?
@@ -411,7 +411,7 @@ module Yast
             UI.QueryWidget(Id(:ntp_address), :Value)
           )
         elsif rv == :next && !Stage.initial
-          # Update UI for the changes ntp servers
+          # Updating UI for the changed ntp servers
           ui_init(Id(:rp), false)
           # show the 'save' status after configuration
           UI.ChangeWidget(Id(:ntp_save), :Value, GetNTPEnabled())

--- a/src/clients/ntp-client_proposal.rb
+++ b/src/clients/ntp-client_proposal.rb
@@ -221,7 +221,7 @@ module Yast
         if NtpClient.GetUsedNtpServers.size > 3
           # TRANSLATOR %{count} number of additional servers
           text << format(_("... (%{count} more servers)"),
-             count: (NtpClient.GetUsedNtpServers.size - counter))
+            count: (NtpClient.GetUsedNtpServers.size - counter))
         end
         ntp_server_widget = Label(text)
       end

--- a/src/clients/ntp-client_proposal.rb
+++ b/src/clients/ntp-client_proposal.rb
@@ -555,6 +555,7 @@ module Yast
       # module which is not defined in the combo box. In that case we do not offer
       # a selection. The user should go back to ntp-client to change it.
       if NtpClient.GetUsedNtpServers.size == 1
+        puts "llll #{fallback_ntp_items}"
         ret = fallback_ntp_items.any? do |item|
           item.params[1] == NtpClient.GetUsedNtpServers.first
         end

--- a/src/clients/ntp-client_proposal.rb
+++ b/src/clients/ntp-client_proposal.rb
@@ -377,7 +377,7 @@ module Yast
 
       # Get the ntp_server value from UI only if isn't present (probably wasn't given as parameter)
       if ntp_server.strip.empty? && select_ntp_server
-        ntp_server = UI.QueryWidget(Id(:ntp_address), :Value)
+        ntp_server = UI.QueryWidget(Id(:ntp_address), :Value) || ""
       end
 
       if !ntp_server.empty? && !ValidateSingleServer(ntp_server)

--- a/src/clients/ntp-client_proposal.rb
+++ b/src/clients/ntp-client_proposal.rb
@@ -303,13 +303,16 @@ module Yast
     def AskUser
       ret = nil
       if select_ntp_server
+        # The user can select ONE ntp server.
+        # So we Initialize the ntp client module with the selected ntp server.
         ntp_server = Convert.to_string(UI.QueryWidget(Id(:ntp_address), :Value))
         return :invalid_hostname unless ValidateSingleServer(ntp_server)
-
         NtpClient.ntp_conf.clear_pools
         NtpClient.ntp_conf.add_pool(ntp_server)
       end
+      # Calling ntp client module.
       ret = :next if WFM.CallFunction("ntp-client")
+      # Initialize the rest
       MakeProposal()
 
       ret

--- a/src/clients/ntp-client_proposal.rb
+++ b/src/clients/ntp-client_proposal.rb
@@ -375,8 +375,9 @@ module Yast
       # Get the ntp_server value from UI only if isn't present (probably wasn't given as parameter)
       if ntp_server.strip.empty? && select_ntp_server
         ntp_server = UI.QueryWidget(Id(:ntp_address), :Value)
-        return :invalid_hostname unless ValidateSingleServer(ntp_server)
       end
+
+      return :invalid_hostname unless ValidateSingleServer(ntp_server)
 
       add_or_install_required_package unless params["write_only"]
 

--- a/src/clients/ntp-client_proposal.rb
+++ b/src/clients/ntp-client_proposal.rb
@@ -555,7 +555,6 @@ module Yast
       # module which is not defined in the combo box. In that case we do not offer
       # a selection. The user should go back to ntp-client to change it.
       if NtpClient.GetUsedNtpServers.size == 1
-        puts "llll #{fallback_ntp_items}"
         ret = fallback_ntp_items.any? do |item|
           item.params[1] == NtpClient.GetUsedNtpServers.first
         end

--- a/src/clients/ntp-client_proposal.rb
+++ b/src/clients/ntp-client_proposal.rb
@@ -413,6 +413,8 @@ module Yast
             UI.QueryWidget(Id(:ntp_address), :Value)
           )
         elsif rv == :next && !Stage.initial
+          # Update UI for the changes ntp servers
+          ui_init(Id(:rp), false)
           # show the 'save' status after configuration
           UI.ChangeWidget(Id(:ntp_save), :Value, GetNTPEnabled())
         end

--- a/src/clients/ntp-client_proposal.rb
+++ b/src/clients/ntp-client_proposal.rb
@@ -175,8 +175,6 @@ module Yast
     end
 
     def MakeProposal
-      ntp_items = []
-
       # On the running system, read all the data, otherwise firewall and other
       # stuff outside ntp.conf may not be initialized correctly (#375877)
       if !Stage.initial
@@ -189,7 +187,7 @@ module Yast
       end
 
       if select_ntp_server
-        ntp_items = fallback_ntp_items if ntp_items.empty?
+        ntp_items = fallback_ntp_items
         # Once read or proposed any config we consider it as read (bnc#427712)
         NtpClient.config_has_been_read = true
 
@@ -534,8 +532,6 @@ module Yast
     # @return [Array<Yast::Term>] ntp address table Item
     def fallback_ntp_items
       dhcp_items = dhcp_ntp_items
-
-      log.info("Nothing found in /etc/chrony.conf")
       if dhcp_items.empty?
         log.info("Proposing current timezone-based NTP server list")
         return timezone_ntp_items

--- a/src/clients/ntp-client_proposal.rb
+++ b/src/clients/ntp-client_proposal.rb
@@ -219,9 +219,9 @@ module Yast
           text << "\n"
         end
         if NtpClient.GetUsedNtpServers.size > 3
-          # TRANSLATOR %1 number of additional servers
-          text << Builtins.sformat(_("... (%1 more servers)"),
-            NtpClient.GetUsedNtpServers.size - counter)
+          # TRANSLATOR %{count} number of additional servers
+          text << format(_("... (%{count} more servers)"),
+             count: (NtpClient.GetUsedNtpServers.size - counter))
         end
         ntp_server_widget = Label(text)
       end

--- a/src/clients/ntp-client_proposal.rb
+++ b/src/clients/ntp-client_proposal.rb
@@ -531,14 +531,14 @@ module Yast
     #
     # @return [Array<Yast::Term>] ntp address table Item
     def fallback_ntp_items
-      dhcp_items = dhcp_ntp_items
-      if dhcp_items.empty?
+      items = dhcp_ntp_items
+      if !items.empty?
+        log.info("Proposing NTP server list provided by DHCP")
+      else
         log.info("Proposing current timezone-based NTP server list")
-        return timezone_ntp_items
+        items = timezone_ntp_items
       end
-
-      log.info("Proposing NTP server list provided by DHCP")
-      dhcp_items
+      items
     end
 
     # Checking if the user can select one ntp server from the list

--- a/test/ntp_client_proposal_test.rb
+++ b/test/ntp_client_proposal_test.rb
@@ -177,4 +177,41 @@ describe Yast::NtpClientProposalClient do
       end
     end
   end
+
+  describe "#select_ntp_server" do
+    context "there are already more than one ntp server defined" do
+      it "returns false" do
+        allow(Yast::NtpClient).to receive(:GetUsedNtpServers).and_return(["n1", "n2"])
+        expect(subject.send(:select_ntp_server)).to eq(false)
+      end
+    end
+
+    context "there is no ntp server defined" do
+      it "returns true" do
+        allow(Yast::NtpClient).to receive(:GetUsedNtpServers).and_return([])
+        expect(subject.send(:select_ntp_server)).to eq(true)
+      end
+    end
+
+    context "there is ONE ntp server defined" do
+      before do
+        allow(Yast::NtpClient).to receive(:dhcp_ntp_servers).and_return([])
+      end
+
+      context "defined server is not in the selection list" do
+        it "returns false" do
+          allow(Yast::NtpClient).to receive(:GetUsedNtpServers).and_return(["not_found"])
+          expect(subject.send(:select_ntp_server)).to eq(false)
+        end
+      end
+
+      context "defined server is in the selection list" do
+        it "returns false" do
+          allow(Yast::NtpClient).to receive(:GetUsedNtpServers).and_return(["de.pool.ntp.org"])
+          expect(subject.send(:select_ntp_server)).to eq(true)
+        end
+      end
+    end
+
+  end
 end

--- a/test/ntp_client_proposal_test.rb
+++ b/test/ntp_client_proposal_test.rb
@@ -139,13 +139,13 @@ describe Yast::NtpClientProposalClient do
         let(:network_running) { true }
 
         it "returns :ntpdate_failed if synchronization fails" do
-          allow(Yast::NtpClient).to receive(:sync_once).with(ntp_server).and_return(1)
+          allow(Yast::NtpClient).to receive(:sync_once).and_return(1)
 
           expect(subject.Write(params)).to eq(:ntpdate_failed)
         end
 
         it "returns :success if synchronization was successfully" do
-          allow(Yast::NtpClient).to receive(:sync_once).with(ntp_server).and_return(0)
+          allow(Yast::NtpClient).to receive(:sync_once).and_return(0)
 
           expect(subject.Write(params)).to eq(:success)
         end

--- a/test/ntp_client_proposal_test.rb
+++ b/test/ntp_client_proposal_test.rb
@@ -207,8 +207,9 @@ describe Yast::NtpClientProposalClient do
 
       context "and defined server is in the selection list" do
         it "returns true" do
-	  allow(Yast::NtpClient).to receive(:GetNtpServersByCountry).and_return(
-		  [Item(Id("de.pool.ntp.org"), "de.pool.ntp.org", true)])
+          allow(Yast::NtpClient).to receive(:GetNtpServersByCountry).and_return(
+            [Item(Id("de.pool.ntp.org"), "de.pool.ntp.org", true)]
+          )
           allow(Yast::NtpClient).to receive(:GetUsedNtpServers).and_return(["de.pool.ntp.org"])
           expect(subject.send(:select_ntp_server)).to eq(true)
         end

--- a/test/ntp_client_proposal_test.rb
+++ b/test/ntp_client_proposal_test.rb
@@ -198,15 +198,17 @@ describe Yast::NtpClientProposalClient do
         allow(Yast::NtpClient).to receive(:dhcp_ntp_servers).and_return([])
       end
 
-      context "defined server is not in the selection list" do
+      context "and defined server is not in the selection list" do
         it "returns false" do
           allow(Yast::NtpClient).to receive(:GetUsedNtpServers).and_return(["not_found"])
           expect(subject.send(:select_ntp_server)).to eq(false)
         end
       end
 
-      context "defined server is in the selection list" do
-        it "returns false" do
+      context "and defined server is in the selection list" do
+        it "returns true" do
+	  allow(Yast::NtpClient).to receive(:GetNtpServersByCountry).and_return(
+		  [Item(Id("de.pool.ntp.org"), "de.pool.ntp.org", true)])
           allow(Yast::NtpClient).to receive(:GetUsedNtpServers).and_return(["de.pool.ntp.org"])
           expect(subject.send(:select_ntp_server)).to eq(true)
         end

--- a/test/ntp_client_proposal_test.rb
+++ b/test/ntp_client_proposal_test.rb
@@ -40,7 +40,7 @@ describe Yast::NtpClientProposalClient do
     end
 
     context "with a not valid hostname" do
-      let(:ntp_server) { nil }
+      let(:ntp_server) { "not_valid" }
 
       it "does not write settings" do
         expect(subject).to_not receive(:WriteNtpSettings)

--- a/test/ntp_client_proposal_test.rb
+++ b/test/ntp_client_proposal_test.rb
@@ -36,6 +36,7 @@ describe Yast::NtpClientProposalClient do
       allow(Yast::Report).to receive(:Error)
       allow(Yast::NetworkService).to receive(:isNetworkRunning).and_return(network_running)
       allow(Yast::Service).to receive(:Active).with(ntp_client.service_name).and_return(false)
+      allow(Yast::NtpClient).to receive(:dhcp_ntp_servers).and_return([])
     end
 
     context "with a not valid hostname" do


### PR DESCRIPTION
**Problem**
The user can select **one** server in the time setting module and can switch to the ntp client module in order to add/update additional one. So the settings/views in both screen are not compatible together.
**Solution**
If more than one ntp server has configured in the ntp client they will be only shown in the time setting screen
![ntp (1)](https://user-images.githubusercontent.com/909986/75978003-de627800-5edd-11ea-9cc9-c4c67aa7212a.png)
**Testing**
Manuel testing. Adapting test cases.
