### PR TITLE
Fix popup

### DIFF
--- a/package/yast2-ntp-client.changes
+++ b/package/yast2-ntp-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb 17 21:19:33 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Adapted unit test to recent changes in Yast::Report (related to
+  bsc#1179893).
+- 4.3.2
+
+-------------------------------------------------------------------
 Mon Aug 10 17:24:06 CEST 2020 - schubi@suse.de
 
 - AutoYaST: Added supplements: autoyast(ntp-client) into the spec file

--- a/package/yast2-ntp-client.spec
+++ b/package/yast2-ntp-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ntp-client
-Version:        4.3.1
+Version:        4.3.2
 Release:        0
 Summary:        YaST2 - NTP Client Configuration
 License:        GPL-2.0-or-later

--- a/test/y2ntp_client/widgets/pool_widgets_test.rb
+++ b/test/y2ntp_client/widgets/pool_widgets_test.rb
@@ -13,6 +13,11 @@ end
 describe Y2NtpClient::Widgets::TestButton do
   subject { described_class.new(double(value: "test.ntp.org")) }
 
+  before do
+    # allow test fail in test env
+    allow(Yast::Report).to receive(:Error)
+  end
+
   include_examples "CWM::PushButton"
 end
 


### PR DESCRIPTION
This pull request in yast-yast2 (https://github.com/yast/yast-yast2/pull/1122) changed the behavior during unit tests of `Yast::Report` and `Yast2::Popup`, making necessary to add some extra mocking to prevent YaST from trying to open windows during the test execution.

As far as we know, that affected the test-suites of: yast-storage-ng, yast-country, yast-firewall, yast-nfs-server, yast-nis-client, yast-pam, yast-security, yast-services-manager and yast-sysconfig.

This should fix the problem for this repository.