### PR TITLE
Fix proposal dhcp_ntp_servers call

### DIFF
--- a/package/yast2-ntp-client.changes
+++ b/package/yast2-ntp-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May  4 10:22:49 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Adapted proposal client returning the dhcp ntp servers as strings
+- 4.4.1 (bsc#1185545)
+
+-------------------------------------------------------------------
 Tue Apr 20 13:51:55 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - 4.4.0 (bsc#1185510)

--- a/package/yast2-ntp-client.spec
+++ b/package/yast2-ntp-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ntp-client
-Version:        4.4.0
+Version:        4.4.1
 Release:        0
 Summary:        YaST2 - NTP Client Configuration
 License:        GPL-2.0-or-later

--- a/src/clients/ntp-client_proposal.rb
+++ b/src/clients/ntp-client_proposal.rb
@@ -60,7 +60,7 @@ module Yast
         NtpClient.ntp_selected = Ops.get_boolean(@param, "ntp_used", false)
         @ret = true
       when "dhcp_ntp_servers"
-        @ret = NtpClient.dhcp_ntp_servers
+        @ret = NtpClient.dhcp_ntp_servers.map(&:hostname)
       when "MakeProposal"
         @ret = MakeProposal()
       when "Write"

--- a/test/ntp_client_proposal_test.rb
+++ b/test/ntp_client_proposal_test.rb
@@ -13,15 +13,36 @@ describe Yast::NtpClientProposalClient do
     client
   end
 
+  let(:dhcp_ntp_servers) { [] }
+
+  before do
+    allow(Yast::Lan).to receive(:dhcp_ntp_servers)
+      .and_return(dhcp_ntp_servers)
+  end
+
+  describe "#main" do
+    let(:client) { described_class.new }
+    let(:func) { "dhcp_ntp_servers" }
+
+    before do
+      allow(Yast::WFM).to receive(:Args).with(no_args).and_return([func])
+      allow(Yast::WFM).to receive(:Args).with(0).and_return(func)
+    end
+
+    context "when call with 'dhcp_ntp_servers' argument" do
+      let(:dhcp_ntp_servers) { ["test.example.net", "test2.example.net"] }
+
+      it "returns servers found via DHCP" do
+        expect(client.main).to eql(dhcp_ntp_servers)
+      end
+    end
+  end
+
   describe "#MakeProposal" do
-    let(:dhcp_ntp_servers) { [] }
     let(:config_was_read?) { false }
     let(:ntp_was_selected?) { false }
 
     before do
-      allow(Yast::Lan).to receive(:dhcp_ntp_servers)
-        .and_return(dhcp_ntp_servers)
-
       allow(Yast::NtpClient).to receive(:country_ntp_servers).with("de")
         .and_return([Y2Network::NtpServer.new("de.pool.ntp.org")])
       allow(Yast::Timezone).to receive(:timezone).and_return("Europe/Berlin")


### PR DESCRIPTION
## Problem

The Timezone Dialog crashes when the ntp proposal client returns some NtpServer.

- https://bugzilla.suse.com/show_bug.cgi?id=1185545

## Solution 

Adapted the code to the changes introduced by https://github.com/yast/yast-network/pull/1039 returning an array of strings instead of NtpServer objects.