### PR TITLE
Unify YaST module mocking in unit tests

### DIFF
--- a/package/yast2-ntp-client.changes
+++ b/package/yast2-ntp-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jan 21 11:55:46 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Unify YaST module mocking in unit tests (related to bsc#1194784)
+- 4.4.2
+
+-------------------------------------------------------------------
 Tue May  4 10:22:49 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Adapted proposal client returning the dhcp ntp servers as strings

--- a/package/yast2-ntp-client.spec
+++ b/package/yast2-ntp-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ntp-client
-Version:        4.4.1
+Version:        4.4.2
 Release:        0
 Summary:        YaST2 - NTP Client Configuration
 License:        GPL-2.0-or-later

--- a/package/yast2-ntp-client.spec
+++ b/package/yast2-ntp-client.spec
@@ -41,6 +41,8 @@ BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 # Y2Network::NtpServer
 BuildRequires:  yast2-network >= 4.2.55
+# yast/rspec/helpers.rb
+BuildRequires:  yast2-ruby-bindings >= 4.4.7
 
 # proper acting TargetFile when scr is switched
 Requires:       augeas-lenses

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,24 +20,6 @@ RSpec.configure do |config|
   end
 end
 
-# stub module to prevent its Import
-# Useful for modules from different yast packages, to avoid build dependencies
-def stub_module(name, fake_class = nil)
-  fake_class = Class.new { def self.fake_method; end } if fake_class.nil?
-  Yast.const_set name.to_sym, fake_class
-end
-
-# stub classes from other modules to speed up a build
-lan = Class.new do
-  def dhcp_ntp_servers
-    []
-  end
-end
-stub_module("Lan", lan)
-stub_module("Language")
-stub_module("Pkg")
-stub_module("PackageCallbacks")
-
 if ENV["COVERAGE"]
   require "simplecov"
   SimpleCov.start do
@@ -65,3 +47,9 @@ if ENV["COVERAGE"]
     ]
   end
 end
+
+# stub classes from other modules to avoid build dependencies
+Yast::RSpec::Helpers.define_yast_module("Lan", methods: [:dhcp_ntp_servers])
+Yast::RSpec::Helpers.define_yast_module("Language")
+Yast::RSpec::Helpers.define_yast_module("PackageCallbacks")
+Yast::RSpec::Helpers.define_yast_module("Pkg")


### PR DESCRIPTION
- Use the new YaST RSpec helper everywhere