### PR TITLE
Skip netconfig configuration when it is not available (bsc#1198066)

### DIFF
--- a/package/yast2-ntp-client.changes
+++ b/package/yast2-ntp-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep 21 13:10:17 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Skip to write and update netconfig configuration when netconfig
+  executable does not exist (bsc#1198066, bsc#1202748)
+- 4.5.1
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.5.0 (bsc#1198109)

--- a/package/yast2-ntp-client.spec
+++ b/package/yast2-ntp-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ntp-client
-Version:        4.5.0
+Version:        4.5.1
 Release:        0
 Summary:        YaST2 - NTP Client Configuration
 License:        GPL-2.0-or-later

--- a/src/modules/NtpClient.rb
+++ b/src/modules/NtpClient.rb
@@ -62,7 +62,6 @@ module Yast
       Yast.import "Language"
       Yast.import "Message"
       Yast.import "Mode"
-      Yast.import "NetworkInterfaces"
       Yast.import "Package"
       Yast.import "Popup"
       Yast.import "Progress"
@@ -338,7 +337,6 @@ module Yast
       return false if !go_next
 
       progress_orig = Progress.set(false)
-      NetworkInterfaces.Read
       Progress.set(progress_orig)
 
       read_policy!

--- a/src/modules/NtpClient.rb
+++ b/src/modules/NtpClient.rb
@@ -40,6 +40,9 @@ module Yast
     # The file name of systemd timer for the synchronization.
     TIMER_PATH = "/etc/systemd/system/#{TIMER_FILE}".freeze
 
+    # @return [String] Netconfig executable
+    NETCONFIG_PATH = "/usr/sbin/netconfig".freeze
+
     UNSUPPORTED_AUTOYAST_OPTIONS = [
       "configure_dhcp",
       "peers",
@@ -156,6 +159,11 @@ module Yast
 
     def progress?
       Mode.normal
+    end
+
+    # return [Boolean] whether netconfig is present in the system or not
+    def netconfig?
+      FileUtils.Exists(NETCONFIG_PATH)
     end
 
     # Synchronize against specified server only one time and does not modify
@@ -387,7 +395,11 @@ module Yast
 
       Report.Error(Message.CannotWriteSettingsTo("/etc/chrony.conf")) if !write_ntp_conf
 
-      write_and_update_policy
+      if netconfig?
+        write_and_update_policy
+      else
+        log.info("There is no netconfig, skipping policy write")
+      end
 
       # restart daemon
       return false if !go_next
@@ -816,7 +828,7 @@ module Yast
     # Calls netconfig to update ntp
     # @return [Boolean] true on success
     def update_netconfig
-      SCR.Execute(path(".target.bash"), "/sbin/netconfig update -m ntp") == 0
+      SCR.Execute(path(".target.bash"), "#{NETCONFIG_PATH} update -m ntp") == 0
     end
 
     # Writes sysconfig ntp policy and calls netconfig to update ntp. Report an

--- a/test/ntp_client_test.rb
+++ b/test/ntp_client_test.rb
@@ -222,6 +222,8 @@ describe Yast::NtpClient do
   end
 
   describe "#Write" do
+    let(:netconfig) { true }
+
     before do
       allow(subject).to receive(:Abort).and_return(false)
       allow(subject).to receive(:go_next).and_return(true)
@@ -229,6 +231,7 @@ describe Yast::NtpClient do
       allow(subject).to receive(:write_ntp_conf).and_return(true)
       allow(subject).to receive(:write_and_update_policy).and_return(true)
       allow(subject).to receive(:check_service)
+      allow(subject).to receive(:netconfig?).and_return(netconfig)
 
       allow(Yast::Report)
     end
@@ -259,10 +262,21 @@ describe Yast::NtpClient do
       expect(lines.lines).to include("pool tik.cesnet.cz iburst\n")
     end
 
-    it "writes ntp policy and updates ntp with netconfig" do
-      expect(subject).to receive(:write_and_update_policy)
+    context "when netconfig is available" do
+      it "writes ntp policy and updates ntp with netconfig" do
+        expect(subject).to receive(:write_and_update_policy)
 
-      subject.Write
+        subject.Write
+      end
+    end
+
+    context "when netconfig is not available" do
+      let(:netconfig) { false }
+      it "skips netconfig configuration" do
+        expect(subject).to_not receive(:write_and_update_policy)
+
+        subject.Write
+      end
     end
 
     context "services will be started" do

--- a/test/ntp_client_test.rb
+++ b/test/ntp_client_test.rb
@@ -4,7 +4,6 @@ require "fileutils"
 require "cfa/memory_file"
 
 Yast.import "NtpClient"
-Yast.import "NetworkInterfaces"
 Yast.import "Package"
 Yast.import "Service"
 
@@ -32,7 +31,6 @@ describe Yast::NtpClient do
     allow(subject).to receive(:go_next).and_return(true)
     allow(subject).to receive(:progress?).and_return(false)
     allow(Yast::Service).to receive(:Enabled).with("chronyd").and_return(true)
-    allow(Yast::NetworkInterfaces).to receive(:Read)
     allow(Yast::Progress)
     allow(Yast::Package).to receive(:CheckAndInstallPackagesInteractive)
       .with(["chrony"]).and_return(true)
@@ -137,7 +135,6 @@ describe Yast::NtpClient do
       allow(subject).to receive(:ReadSynchronization)
       allow(subject).to receive(:read_policy!)
       allow(Yast::Service).to receive(:Enabled).with("chronyd").and_return(true)
-      allow(Yast::NetworkInterfaces).to receive(:Read)
       allow(Yast::Progress)
       allow(Yast::Package).to receive(:CheckAndInstallPackagesInteractive)
         .with(["chrony"]).and_return(true)
@@ -165,12 +162,6 @@ describe Yast::NtpClient do
 
       it "doesn't show progress if it is not in normal Mode" do
         expect(Yast::Progress).not_to receive(:New)
-
-        subject.Read
-      end
-
-      it "reads network interfaces config" do
-        expect(Yast::NetworkInterfaces).to receive(:Read)
 
         subject.Read
       end

--- a/test/y2ntp_client/client/auto_test.rb
+++ b/test/y2ntp_client/client/auto_test.rb
@@ -14,7 +14,6 @@ describe Y2NtpClient::Client::Auto do
 
   before do
     allow(Yast::Service).to receive(:Enabled).with("chronyd").and_return(true)
-    allow(Yast::NetworkInterfaces).to receive(:Read)
     allow(Yast::Package).to receive(:CheckAndInstallPackagesInteractive)
       .with(["chrony"]).and_return(true)
     Yast::NtpClient.Read


### PR DESCRIPTION
## Problem

During installation, we try to call **netconfig** for writing and updating the ntp policy even when **netconfig** it is not available.

- [bsc#1198066](https://bugzilla.suse.com/show_bug.cgi?id=1198066)

## Solution

Skip netconfig configuration if it is not available

## Testing

- *Added a new unit test*

