### PR TITLE
Fix netconfit path

### DIFF
--- a/package/yast2-ntp-client.changes
+++ b/package/yast2-ntp-client.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Nov 21 14:40:27 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix the netconfig executable path using /sbin/netconfig instead
+  of /usr/sbin/netconfig which is not available in SLE-15-SP5
+  (bsc#1205401)
+- 4.5.2
+
+-------------------------------------------------------------------
 Wed Sep 21 13:10:17 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Skip to write and update netconfig configuration when netconfig

--- a/package/yast2-ntp-client.spec
+++ b/package/yast2-ntp-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ntp-client
-Version:        4.5.1
+Version:        4.5.2
 Release:        0
 Summary:        YaST2 - NTP Client Configuration
 License:        GPL-2.0-or-later

--- a/src/modules/NtpClient.rb
+++ b/src/modules/NtpClient.rb
@@ -40,8 +40,10 @@ module Yast
     # The file name of systemd timer for the synchronization.
     TIMER_PATH = "/etc/systemd/system/#{TIMER_FILE}".freeze
 
+    # FIXME: We should avoid the use of the full path as it could be problematic with or without
+    # usr-merge (bsc#1205401)
     # @return [String] Netconfig executable
-    NETCONFIG_PATH = "/usr/sbin/netconfig".freeze
+    NETCONFIG_PATH = "/sbin/netconfig".freeze
 
     UNSUPPORTED_AUTOYAST_OPTIONS = [
       "configure_dhcp",


### PR DESCRIPTION
## Problem

In #174 we fixed a Tumbleweed bug avoiding to call **netconfig** when it was not present in the system but as consequence of that bug the executable is probably not called anymore in **SLE-15-SP5** as we modified the full path of the executable to be **/usr/sbin/netconfig** which is wrong as it should be **/sbin/netconfig**.

- [*bsc#1205401*](https://bugzilla.suse.com/show_bug.cgi?id=1205401)

## Solution

Fix the **netconfig full path** in **SLE-15-SP5** by now although we should look for a better solution in order to not use full paths anymore avoiding these kinds of problems **(usr-merge)**.

